### PR TITLE
YPP-0004: Give developer role to 0xC7aE076

### DIFF
--- a/YPP-0001.md
+++ b/YPP-0001.md
@@ -1,0 +1,33 @@
+# Proposal
+Give developer role to 0xC7aE076086623ecEA2450e364C838916a043F9a8, controlled by @alcueca
+
+# Background
+There aren't any accounts with a developer role, which allows for a safer operation of the protocol. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
+
+# Details
+
+```
+  const newDeveloper = '0xC7aE076086623ecEA2450e364C838916a043F9a8'
+  const proposal: Array<{ target: string; data: string }> = []
+  proposal.push({
+    target: timelock.address,
+    data: timelock.interface.encodeFunctionData('grantRoles', [
+      [
+        '0xca02753a', // propose,
+        '0x013a652d', // proposeRepeated
+        '0xbaae8abf', // execute
+        '0xf9a28e8b', // executeRepeated
+      ],
+      newDeveloper,
+    ]),
+  })
+  proposal.push({
+    target: cloak.address,
+    data: cloak.interface.encodeFunctionData('grantRoles', [
+      [
+        id(cloak.interface, 'execute(bytes32)')
+      ],
+      newDeveloper,
+    ]),
+  })
+```


### PR DESCRIPTION
# Proposal
Give developer role to 0xC7aE076086623ecEA2450e364C838916a043F9a8, controlled by @alcueca

# Background
There aren't any accounts with a developer role, which allows for a safer operation of the protocol. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.

# Details

```
  const newDeveloper = '0xC7aE076086623ecEA2450e364C838916a043F9a8'
  const proposal: Array<{ target: string; data: string }> = []
  proposal.push({
    target: timelock.address,
    data: timelock.interface.encodeFunctionData('grantRoles', [
      [
        '0xca02753a', // propose,
        '0x013a652d', // proposeRepeated
        '0xbaae8abf', // execute
        '0xf9a28e8b', // executeRepeated
      ],
      newDeveloper,
    ]),
  })
  proposal.push({
    target: cloak.address,
    data: cloak.interface.encodeFunctionData('grantRoles', [
      [
        id(cloak.interface, 'execute(bytes32)')
      ],
      newDeveloper,
    ]),
  })
```