### PR TITLE
YPP-0005: Give developer role to 0x2bBA525

### DIFF
--- a/YPP-0005.md
+++ b/YPP-0005.md
@@ -1,0 +1,35 @@
+# Proposal
+Give developer role to 0x2bBA525c4891603C4c37F635d899918B6a23aCFf, controlled by @aniemerg
+
+# Background
+There is only one account with a developer role, which allows for execution of emergency plans, among other rights. For safe 24h operations we need accounts with developer roles in all timezones.
+
+Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
+
+# Details
+
+```
+  const newDeveloper = '0x2bBA525c4891603C4c37F635d899918B6a23aCFf'
+  const proposal: Array<{ target: string; data: string }> = []
+  proposal.push({
+    target: timelock.address,
+    data: timelock.interface.encodeFunctionData('grantRoles', [
+      [
+        '0xca02753a', // propose,
+        '0x013a652d', // proposeRepeated
+        '0xbaae8abf', // execute
+        '0xf9a28e8b', // executeRepeated
+      ],
+      newDeveloper,
+    ]),
+  })
+  proposal.push({
+    target: cloak.address,
+    data: cloak.interface.encodeFunctionData('grantRoles', [
+      [
+        id(cloak.interface, 'execute(bytes32)')
+      ],
+      newDeveloper,
+    ]),
+  })
+```


### PR DESCRIPTION
**Proposal**
Give developer role to 0x2bBA525c4891603C4c37F635d899918B6a23aCFf, controlled by @aniemerg 

**Background**
There is only one account with a developer role, which allows for execution of emergency plans, among other rights. For safe 24h operations we need accounts with developer roles in all timezones.

Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.

**Details**
```
  const newDeveloper = '0x2bBA525c4891603C4c37F635d899918B6a23aCFf'
  const proposal: Array<{ target: string; data: string }> = []
  proposal.push({
    target: timelock.address,
    data: timelock.interface.encodeFunctionData('grantRoles', [
      [
        '0xca02753a', // propose,
        '0x013a652d', // proposeRepeated
        '0xbaae8abf', // execute
        '0xf9a28e8b', // executeRepeated
      ],
      newDeveloper,
    ]),
  })
  proposal.push({
    target: cloak.address,
    data: cloak.interface.encodeFunctionData('grantRoles', [
      [
        id(cloak.interface, 'execute(bytes32)')
      ],
      newDeveloper,
    ]),
  })
```
