### PR TITLE
YPP-0006: Raise ETH ceiling limits to $500K

### DIFF
--- a/YPP-0006.md
+++ b/YPP-0006.md
@@ -1,0 +1,24 @@
+# Proposal
+Raise DAI/ETH and USDC/ETH ceiling limits to 500K DAI and 500K USDC respectively
+
+# Background
+Due to unprecedented demand, the limits for borrowing DAI or USDC with ETH as collateral have already been reached.
+
+At the same time, there haven't been any major incidents yet, and samczsun hasn't managed to hack Yield v2, so we feel more confident in the protocol.
+
+# Details
+The updateCeiling.ts script will be used, with this input:
+
+```
+/**
+ * @dev Input file for updateCeiling.ts
+ */
+
+import { ETH, DAI, USDC, WBTC, USDT } from '../../../shared/constants'
+
+// Input data: baseId, ilkId, maxDebt
+export const newMax: Array<[string, string, number]> = [
+  [DAI, ETH, 500000],
+  [USDC, ETH, 500000],
+]
+```


### PR DESCRIPTION
**Proposal**
Raise DAI/ETH and USDC/ETH ceiling limits to 500K DAI and 500K USDC respectively

**Background**
Due to unprecedented demand, the limits for borrowing DAI or USDC with ETH as collateral have already been reached.

At the same time, there haven't been any major incidents yet, and samczsun hasn't managed to hack Yield v2, so we feel more confident in the protocol.

**Details**
The [`updateCeiling.ts`](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/operations/limits/updateCeiling.ts) script will be used, with this [input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/operations/limits/updateCeiling.config.ts):
```
/**
 * @dev Input file for updateCeiling.ts
 */

import { ETH, DAI, USDC, WBTC, USDT } from '../../../shared/constants'

// Input data: baseId, ilkId, maxDebt
export const newMax: Array<[string, string, number]> = [
  [DAI, ETH, 500000],
  [USDC, ETH, 500000],
]
```