### PR TITLE
Enable wstETH as a collateral for DAI and USDC

### DIFF
--- a/YPP-0007.md
+++ b/YPP-0007.md
@@ -14,16 +14,22 @@ The [deployLidoOracle.ts](https://github.com/yieldprotocol/environments-v2/blob/
 
 The [deployCompositeOracle.ts](https://github.com/yieldprotocol/environments-v2/blob/gov/ypp-0007/scripts/operations/oracles/deployCompositeOracle.ts) script will be used, with no input.
 
-**3. Add WstETH as an asset**
+**3. Add WstETH as an asset, and reserve the stETH id in the Cauldron**
 
 The [ypp-0007-3.ts](https://github.com/yieldprotocol/environments-v2/blob/5999b5e9f905ed93ffe34c84968b0db27871acdd/scripts/operations/governance/ypp-0007/ypp-0007-3.ts) script will be used, with this input:
 
 ```
-// https://docs.lido.fi/deployed-contracts
-const wstEthAddress: string = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0' 
-  const assets: Array<[string, string]> = [
+   // https://docs.lido.fi/deployed-contracts
+  const wstEthAddress: string = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
+  const stEthAddress: string = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
+  
+  const addedAssets: Array<[string, string]> = [
     [WSTETH, wstEthAddress],
   ]
+  const reservedAssets: Array<[string, string]> = [
+    [STETH, stEthAddress],
+  ]
+
 ```
 
 **4. Configure the protocol**
@@ -82,4 +88,28 @@ And these inputs:
     [stringToBytes6('0204'), [WSTETH]],
     [stringToBytes6('0205'), [WSTETH]],
   ]
+```
+# Testing
+The change has been tested on a mainnet fork by posting wstETH to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/blob/feat/composite-oracle/scripts/operations/governance/ypp-0007/ypp-0007.test.ts).
+```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/ypp-0007/ypp-0007.test.ts 
+No need to generate any newer typings.
+Running on a fork, impersonating 0xdaef20ea4708fcff06204a4fe9ddf41db056ba18
+6897357956874283776035 wstETH available
+series: 0x303130340000
+vault: 0x3b566fb4defd155c3235cee3
+posted and borrowed
+repaid and withdrawn
+series: 0x303130350000
+vault: 0x7749751febed1b3925df8764
+posted and borrowed
+repaid and withdrawn
+series: 0x303230340000
+vault: 0x1ff4c3b2edfd32b60b942cd1
+posted and borrowed
+repaid and withdrawn
+series: 0x303230350000
+vault: 0x72ee485080a190a40961dab7
+posted and borrowed
+repaid and withdrawn
 ```


### PR DESCRIPTION
# Proposal
Enable wstETH as a collateral for DAI and USDC

# Background
wstETH has a $359M market cap, is yield-bearing, and has limited options to be used as collateral. This is an initial step to add ETH-denominated series, and stETH as collateral via wrapping into wstETH.

# Details

**1. Deploy LidoOracle**

The [deployLidoOracle.ts](https://github.com/yieldprotocol/environments-v2/blob/1d5ced1399ded4b4389a2ee1bd1d1234ca5ce283/scripts/operations/oracles/deployLidoOracle.ts) script will be used, with no input.

**2. Deploy CompositeMultiOracle**

The [deployCompositeOracle.ts](https://github.com/yieldprotocol/environments-v2/blob/gov/ypp-0007/scripts/operations/oracles/deployCompositeOracle.ts) script will be used, with no input.

**3. Add WstETH as an asset, and reserve the stETH id in the Cauldron**

The [ypp-0007-3.ts](https://github.com/yieldprotocol/environments-v2/blob/5999b5e9f905ed93ffe34c84968b0db27871acdd/scripts/operations/governance/ypp-0007/ypp-0007-3.ts) script will be used, with this input:

```
   // https://docs.lido.fi/deployed-contracts
  const wstEthAddress: string = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
  const stEthAddress: string = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
  
  const addedAssets: Array<[string, string]> = [
    [WSTETH, wstEthAddress],
  ]
  const reservedAssets: Array<[string, string]> = [
    [STETH, stEthAddress],
  ]

```

**4. Configure the protocol**

The rest of the configuration will be condensed into a single proposal with the [ypp-0007-4.ts](https://github.com/yieldprotocol/environments-v2/blob/5999b5e9f905ed93ffe34c84968b0db27871acdd/scripts/operations/governance/ypp-0007/ypp-0007-4.ts) script, which includes these actions:

1. Configure the permissions for the Lido Oracle
2. Add WstETH as the source for the Lido Oracle
3. Add the stETH/ETH source to the Chainlink Oracle
4. Deploy the Composite Oracle
5. Add the underlying sources for the Composite Oracle
6. Add the DAI/WSTETH and USDC/WSTETH paths in the Composite Oracle
7. Permission the WstETHJoin
8. Make WstETH into an Ilk
9. Approve WstEth as collateral for all series

And these inputs:
```
  const CHAINLINK = 'chainlinkOracle'
  const LIDO = 'lidoOracle'
  const COMPOSITE = 'compositeOracle'

  const wstEthAddress: string = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0' // https://docs.lido.fi/deployed-contracts
  const stEthAddress: string = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84' // https://docs.lido.fi/deployed-contracts
  const wethAddress: string = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
  // Input data: baseId, base address, quoteId, quote address, oracle name, source address
  const stEthEthSource: Array<[string, string, string, string, string, string]> = [
    [STETH, stEthAddress, ETH, wethAddress, CHAINLINK,  '0x86392dC19c0b719886221c78AB11eb8Cf5c52812'], // https://docs.lido.fi/deployed-contracts
  ]
  // Input data: baseId, quoteId, oracle name
  const compositeSources: Array<[string, string, string]> = [
    [DAI,    ETH,   CHAINLINK],
    [USDC,   ETH,   CHAINLINK],
    [WBTC,   ETH,   CHAINLINK],
    [STETH,  ETH,   CHAINLINK],
    [WSTETH, STETH, LIDO],
  ]
  // Input data: assetId, assetId, [intermediate assetId]
  const compositePaths: Array<[string, string, Array<string>]> = [
    [WSTETH, DAI, [STETH, ETH]],
    [WSTETH, USDC, [STETH, ETH]],
  ]
  // Input data: assetId, asset address
  const assets: Array<[string, string]> = [
    [WSTETH, wstEthAddress],
  ]
  // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
  const ilks: Array<[string, string, string, number, number, number, number, number]> = [
    [DAI, WSTETH, COMPOSITE, 1400000, 714000, 500000, 1, 18],
    [USDC, WSTETH, COMPOSITE, 1400000, 714000, 500000, 1, 6],
  ]
  // Input data: seriesId, [ilkId]
  const seriesIlks: Array<[string, string[]]> = [
    [stringToBytes6('0104'), [WSTETH]],
    [stringToBytes6('0105'), [WSTETH]],
    [stringToBytes6('0204'), [WSTETH]],
    [stringToBytes6('0205'), [WSTETH]],
  ]
```
# Testing
The change has been tested on a mainnet fork by posting wstETH to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/blob/feat/composite-oracle/scripts/operations/governance/ypp-0007/ypp-0007.test.ts).
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/ypp-0007/ypp-0007.test.ts 
No need to generate any newer typings.
Running on a fork, impersonating 0xdaef20ea4708fcff06204a4fe9ddf41db056ba18
6897357956874283776035 wstETH available
series: 0x303130340000
vault: 0x3b566fb4defd155c3235cee3
posted and borrowed
repaid and withdrawn
series: 0x303130350000
vault: 0x7749751febed1b3925df8764
posted and borrowed
repaid and withdrawn
series: 0x303230340000
vault: 0x1ff4c3b2edfd32b60b942cd1
posted and borrowed
repaid and withdrawn
series: 0x303230350000
vault: 0x72ee485080a190a40961dab7
posted and borrowed
repaid and withdrawn
```