### PR TITLE
Revoke all permissions from deployer account

### DIFF
--- a/YPP-0008.md
+++ b/YPP-0008.md
@@ -5,3 +5,7 @@ Remove all permissions from deployer.
 The deployer account at 0xa072f81fea73ca932ab2b5eda31fa29306d58708 was used to deploy the protocol bypassing the multisig. Now it is a risk in that it is a single account with total control over the protocol. This proposal will remove all permissions from the deployer to remove that risk.
 
 # Details
+The [ypp-0008.ts](https://github.com/yieldprotocol/environments-v2/blob/fa7e8dcbd90770e7ab205eeb82fae239fabb3547/scripts/operations/governance/ypp-0008/ypp-0008.ts) script will be executed, taking as its sole input the deployer address:
+```
+const deployer: string = '0xA072f81Fea73Ca932aB2B5Eda31Fa29306D58708'
+```


### PR DESCRIPTION
# Proposal
Remove all permissions from deployer.

# Background
The deployer account at 0xa072f81fea73ca932ab2b5eda31fa29306d58708 was used to deploy the protocol bypassing the multisig. Now it is a risk in that it is a single account with total control over the protocol. This proposal will remove all permissions from the deployer to remove that risk.

# Details
The [ypp-0008.ts](https://github.com/yieldprotocol/environments-v2/blob/fa7e8dcbd90770e7ab205eeb82fae239fabb3547/scripts/operations/governance/ypp-0008/ypp-0008.ts) script will be executed, taking as its sole input the deployer address:
```
const deployer: string = '0xA072f81Fea73Ca932aB2B5Eda31Fa29306D58708'
```