### PR TITLE
Raise dust level in all base/collateral pairs

### DIFF
--- a/YPP-0009.md
+++ b/YPP-0009.md
@@ -2,7 +2,89 @@
 Raise the dust level in all base/collateral pairs
 
 # Background
+The dust (min debt) level for a vault is set to $1 currently. This leads to situations where vaults become unprofitable to liquidate. This proposal will increase the dust level so that the probability of liquidations providing some profits increases.
 
 # Details
+The [ypp-0009.ts][https://github.com/yieldprotocol/environments-v2/blob/ops/raise-dust-level/scripts/operations/governance/ypp-0009/ypp-0009.ts] script will be used, with this input:
+```
+/**
+ * @dev Input file for ypp-0009.ts
+ */
 
+import { ETH, DAI, USDC, WBTC, WSTETH } from '../../../../shared/constants'
+
+// Input data: baseId, ilkId, maxDebt
+export const newMin: Array<[string, string, number]> = [
+  [DAI, ETH, 100],
+  [DAI, WSTETH, 100],
+  [DAI, USDC, 100],
+  [DAI, WBTC, 100],
+  [USDC, ETH, 100],
+  [USDC, WSTETH, 100],
+  [USDC, DAI, 100],
+  [USDC, WBTC, 100],
+]
+
+```
 # Testing
+The change has been tested on a mainnet fork by running [ypp-0009.ts][https://github.com/yieldprotocol/environments-v2/blob/ops/raise-dust-level/scripts/operations/governance/ypp-0009/ypp-0009.ts] first followed by [ypp-0009.test.ts][https://github.com/yieldprotocol/environments-v2/blob/ops/raise-dust-level/scripts/operations/governance/ypp-0009/ypp-0009.test.ts] to verify that the changes were made.
+```
+Praffuls-MacBook-Pro:environments-v2 praffulsahu$ npx hardhat run --network localhost scripts/operations/governance/ypp-0009/ypp-0009.ts
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+01/00: 1 -> 100
+01/04: 1 -> 100
+01/02: 1 -> 100
+01/03: 1 -> 100
+02/00: 1 -> 100
+02/04: 1 -> 100
+02/01: 1 -> 100
+02/03: 1 -> 100
+Proposal: 0x0e7582164127ebae0e846a4d5349baf829949a9c9346c927c054f83cc9956d7b
+Proposed 0x0e7582164127ebae0e846a4d5349baf829949a9c9346c927c054f83cc9956d7b
+
+Praffuls-MacBook-Pro:environments-v2 praffulsahu$ npx hardhat run --network localhost scripts/operations/governance/ypp-0009/ypp-0009.ts
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+01/00: 1 -> 100
+01/04: 1 -> 100
+01/02: 1 -> 100
+01/03: 1 -> 100
+02/00: 1 -> 100
+02/04: 1 -> 100
+02/01: 1 -> 100
+02/03: 1 -> 100
+Proposal: 0x0e7582164127ebae0e846a4d5349baf829949a9c9346c927c054f83cc9956d7b
+Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
+Approved 0x0e7582164127ebae0e846a4d5349baf829949a9c9346c927c054f83cc9956d7b
+
+Praffuls-MacBook-Pro:environments-v2 praffulsahu$ npx hardhat run --network localhost scripts/operations/governance/ypp-0009/ypp-0009.ts
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+01/00: 1 -> 100
+01/04: 1 -> 100
+01/02: 1 -> 100
+01/03: 1 -> 100
+02/00: 1 -> 100
+02/04: 1 -> 100
+02/01: 1 -> 100
+02/03: 1 -> 100
+Proposal: 0x0e7582164127ebae0e846a4d5349baf829949a9c9346c927c054f83cc9956d7b
+Running on a fork, will execute
+Executed 0x0e7582164127ebae0e846a4d5349baf829949a9c9346c927c054f83cc9956d7b
+
+Praffuls-MacBook-Pro:environments-v2 praffulsahu$ npx hardhat run --network localhost scripts/operations/governance/ypp-0009/ypp-0009.test.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+01/00 set: 100
+01/04 set: 100
+01/02 set: 100
+01/03 set: 100
+02/00 set: 100
+02/04 set: 100
+02/01 set: 100
+02/03 set: 100
+```


### PR DESCRIPTION
Proposal
Raise the dust level in all base/collateral pairs

Background
The dust (min debt) level for a vault is set to $1 currently. This leads to situations where vaults become unprofitable to liquidate. This proposal will increase the dust level so that the liquidations of vaults provide some profits.