### PR TITLE
Update ceiling for USDC/ETH to 1000000

### DIFF
--- a/YPP-0011.md
+++ b/YPP-0011.md
@@ -1,0 +1,54 @@
+# Proposal
+Raise the ceiling level for USDC/ETH to 1000000
+
+# Background
+The ceiling (max debt) level for USDC borrowing with ETH collateral is set to 500,000 currently, while the total borrowed amount for that pair is 335,851.
+
+# Details
+The [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) script will be used, with this input:
+```
+// Input data: baseId, ilkId, maxDebt
+export const newMax: Array<[string, string, number]> = [
+  [USDC, ETH, 1000000],
+]
+
+```
+# Testing
+The change has been tested on a mainnet fork by running [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) first followed by [updateCeiling.test.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.test.ts) to verify that the changes were made.
+```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00: 500000 -> 1000000
+Proposal: 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
+Proposed 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
+
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00: 500000 -> 1000000
+Proposal: 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
+Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
+Approved 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
+
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00: 500000 -> 1000000
+Proposal: 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
+Executed 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
+
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.test.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00 set: 1000000
+
+```


### PR DESCRIPTION
# Proposal
Raise the ceiling level for USDC/ETH to 1000000

# Background
The ceiling (max debt) level for USDC borrowing with ETH collateral is set to 500,000 currently, while the total borrowed amount for that pair is 335,851.

# Details
The [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) script will be used, with this input:
```
// Input data: baseId, ilkId, maxDebt
export const newMax: Array<[string, string, number]> = [
  [USDC, ETH, 1000000],
]

```
# Testing
The change has been tested on a mainnet fork by running [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) first followed by [updateCeiling.test.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.test.ts) to verify that the changes were made.
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00: 500000 -> 1000000
Proposal: 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
Proposed 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f

alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00: 500000 -> 1000000
Proposal: 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
Approved 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f

alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00: 500000 -> 1000000
Proposal: 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f
Executed 0x1841bcf0cba598a418d14d48e993dcd99737fdcaa2f20e2ff0c2b16fc1a95b5f

alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/operations/governance/updateCeiling/updateCeiling.test.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00 set: 1000000

```