### PR TITLE
Add ENS as a collateral

### DIFF
--- a/YPP-0014.md
+++ b/YPP-0014.md
@@ -1,0 +1,137 @@
+# Proposal
+Enable ENS as a collateral for DAI and USDC
+
+# Background
+ENS has a $4,580M market cap and 58K holders, while the market has still scarce options to use it as collateral. Enabling it as a collateral in the yield Protocol is expected to spur borrowing demand.
+
+To enable ENS as a collateral we will be using the ETH/ENS 0.3% Uniswap v3 Pool as a source of price data. The debt ceiling for ENS against all underlyings won't exceed the $12.45m TVL of the pool.
+
+# Details
+
+**1. Deploy UniswapOracle**
+
+The [deployUniswapOracle.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/oracles/uniswap/deployUniswapOracle.ts) script will be used, with no input.
+
+**2. Orchestrate and configure oracles**
+
+The [addENS-2.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS-2.ts) script will be used, with this input:
+
+```
+  const UNISWAP = 'uniswapOracle'
+  const CHAINLINK = 'chainlinkOracle'
+
+  const ensEthPoolAddress: string = '0x92560c178ce069cc014138ed3c2f5221ba71f58a' // https://info.uniswap.org/#/tokens/0xc18360217d8f7ab5e7c516566761ea12ce7f9d72
+  const kovanEnsEthSource = '0x19d7cCdB7B4caE085d3Fda330A01D139d7243Be4' // From spotSources.json in addresses archive
+  const kovanEnsAddress = '0xA24b97c7617cc40dCc122F6dF813584A604a6C28' // From assets.json in addresses archive
+  const kovanWethAddress = '0x55C0458edF1D8E07DF9FB44B8960AecC515B4492' // From assets.json in addresses archive
+
+  // Input data: baseId, quoteId, oracle name, pool address and twapInterval. baseId must match token0 and quoteId must match token1.
+  const uniswapSources: Array<[string, string, string, string, number]> = [[ETH, ENS, UNISWAP, ensEthPoolAddress, 600]]
+
+  // Input data: baseId, base address, quoteId, quote address, oracle name, source address
+  const chainlinkSources: Array<[string, string, string, string, string, string]> = [
+    [ENS, kovanEnsAddress as string, ETH, kovanWethAddress as string, CHAINLINK, kovanEnsEthSource],
+  ]
+  // Input data: baseId, quoteId, oracle name
+  const compositeSources: Map<number, Array<[string, string, string]>> = new Map([
+    [1, [[ENS, ETH, UNISWAP]]],
+    [42, [[ENS, ETH, CHAINLINK]]],
+  ])
+  // Input data: assetId, assetId, [intermediate assetId]
+  const compositePaths: Array<[string, string, Array<string>]> = [
+    [ENS, DAI, [ETH]],
+    [ENS, USDC, [ETH]],
+  ]
+```
+
+Executing this step allows us to [test](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS.test.ts) already the ENS/ETH/, ENS/DAI and ENS/USDC prices:
+
+```
+$ npx hardhat run --network localhost scripts/operations/governance/addCompositeCollateral/getENSPrice.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+ENS/ETH: 11254630275577490,1637321573
+ETH/ENS: 88852319046854573595,1637321573
+ENS/DAI: 46704612562947242241,0
+DAI/ENS: 21411161449037316,0
+ENS/USDC: 46429992,0
+USDC/ENS: 21537802136957548639588635289,0
+```
+
+**3. Add ENS as an asset using the Wand**
+
+The [addENS-3.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS-3.ts) script will be used, with this input:
+
+```
+  const ensAddress = new Map([
+    [1, '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72'],
+    [42, '0xA24b97c7617cc40dCc122F6dF813584A604a6C28'],
+  ]) // https://ens.mirror.xyz/5cGl-Y37aTxtokdWk21qlULmE1aSM_NuX9fstbOPoWU
+  
+  const addedAssets: Array<[string, string]> = [
+    [ENS, ensAddress.get(chainId) as string],
+  ]
+
+```
+
+**4. Configure the protocol**
+
+The rest of the configuration will be condensed into a single proposal with the [addENS-4.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS-4.ts) script, which includes these actions:
+
+1. Permission the ENSJoin
+2. Make ENS into an Ilk
+3. Approve ENS as collateral for all series
+
+And these inputs:
+```
+  const COMPOSITE = 'compositeOracle'
+
+  const ensAddress = new Map([
+    [1, '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72'],
+    [42, '0xA24b97c7617cc40dCc122F6dF813584A604a6C28'],
+  ]) // https://ens.mirror.xyz/5cGl-Y37aTxtokdWk21qlULmE1aSM_NuX9fstbOPoWU
+  
+  // Input data: assetId, asset address
+  const addedAssets: Array<[string, string]> = [
+    [ENS, ensAddress.get(chainId) as string],
+  ]
+  // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
+  const ilks: Array<[string, string, string, number, number, number, number, number]> = [
+    [DAI, ENS, COMPOSITE, 1670000, 600000, 500000, 100, 18],
+    [USDC, ENS, COMPOSITE, 1670000, 600000, 500000, 100, 6],
+  ]
+  // Input data: seriesId, [ilkId]
+  const seriesIlks: Array<[string, string[]]> = [
+    [stringToBytes6('0104'), [ENS]],
+    [stringToBytes6('0105'), [ENS]],
+    [stringToBytes6('0204'), [ENS]],
+    [stringToBytes6('0205'), [ENS]],
+  ]
+```
+# Testing
+The change has been tested on a mainnet fork by posting ENS to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS.test.ts).
+```
+$ npx hardhat run --network localhost scripts/operations/governance/addCompositeCollateral/addENS.test.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+65532017200000000000000000 ENS available
+series: 0x303130340000
+vault: 0x11000df708d0c0ce84929b99
+posted and borrowed
+repaid and withdrawn
+series: 0x303130350000
+vault: 0x48a84506528015d548819131
+posted and borrowed
+repaid and withdrawn
+series: 0x303230340000
+vault: 0x9433ee0ef41c983b6ee795b0
+posted and borrowed
+repaid and withdrawn
+series: 0x303230350000
+vault: 0x749cff617e7cd873f1897420
+posted and borrowed
+repaid and withdrawn
+```


### PR DESCRIPTION
# Proposal
Enable ENS as a collateral for DAI and USDC

# Background
ENS has a $4,580M market cap and 58K holders, while the market has still scarce options to use it as collateral. Enabling it as a collateral in the yield Protocol is expected to spur borrowing demand.

To enable ENS as a collateral we will be using the ETH/ENS 0.3% Uniswap v3 Pool as a source of price data. The debt ceiling for ENS against all underlyings won't exceed the $12.45m TVL of the pool.

# Details

**1. Deploy UniswapOracle**

The [deployUniswapOracle.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/oracles/uniswap/deployUniswapOracle.ts) script will be used, with no input.

**2. Orchestrate and configure oracles**

The [addENS-2.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS-2.ts) script will be used, with this input:

```
  const UNISWAP = 'uniswapOracle'
  const CHAINLINK = 'chainlinkOracle'

  const ensEthPoolAddress: string = '0x92560c178ce069cc014138ed3c2f5221ba71f58a' // https://info.uniswap.org/#/tokens/0xc18360217d8f7ab5e7c516566761ea12ce7f9d72
  const kovanEnsEthSource = '0x19d7cCdB7B4caE085d3Fda330A01D139d7243Be4' // From spotSources.json in addresses archive
  const kovanEnsAddress = '0xA24b97c7617cc40dCc122F6dF813584A604a6C28' // From assets.json in addresses archive
  const kovanWethAddress = '0x55C0458edF1D8E07DF9FB44B8960AecC515B4492' // From assets.json in addresses archive

  // Input data: baseId, quoteId, oracle name, pool address and twapInterval. baseId must match token0 and quoteId must match token1.
  const uniswapSources: Array<[string, string, string, string, number]> = [[ETH, ENS, UNISWAP, ensEthPoolAddress, 600]]

  // Input data: baseId, base address, quoteId, quote address, oracle name, source address
  const chainlinkSources: Array<[string, string, string, string, string, string]> = [
    [ENS, kovanEnsAddress as string, ETH, kovanWethAddress as string, CHAINLINK, kovanEnsEthSource],
  ]
  // Input data: baseId, quoteId, oracle name
  const compositeSources: Map<number, Array<[string, string, string]>> = new Map([
    [1, [[ENS, ETH, UNISWAP]]],
    [42, [[ENS, ETH, CHAINLINK]]],
  ])
  // Input data: assetId, assetId, [intermediate assetId]
  const compositePaths: Array<[string, string, Array<string>]> = [
    [ENS, DAI, [ETH]],
    [ENS, USDC, [ETH]],
  ]
```

Executing this step allows us to [test](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS.test.ts) already the ENS/ETH/, ENS/DAI and ENS/USDC prices:

```
$ npx hardhat run --network localhost scripts/operations/governance/addCompositeCollateral/getENSPrice.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
ENS/ETH: 11254630275577490,1637321573
ETH/ENS: 88852319046854573595,1637321573
ENS/DAI: 46704612562947242241,0
DAI/ENS: 21411161449037316,0
ENS/USDC: 46429992,0
USDC/ENS: 21537802136957548639588635289,0
```

**3. Add ENS as an asset using the Wand**

The [addENS-3.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS-3.ts) script will be used, with this input:

```
  const ensAddress = new Map([
    [1, '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72'],
    [42, '0xA24b97c7617cc40dCc122F6dF813584A604a6C28'],
  ]) // https://ens.mirror.xyz/5cGl-Y37aTxtokdWk21qlULmE1aSM_NuX9fstbOPoWU
  
  const addedAssets: Array<[string, string]> = [
    [ENS, ensAddress.get(chainId) as string],
  ]

```

**4. Configure the protocol**

The rest of the configuration will be condensed into a single proposal with the [addENS-4.ts](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS-4.ts) script, which includes these actions:

1. Permission the ENSJoin
2. Make ENS into an Ilk
3. Approve ENS as collateral for all series

And these inputs:
```
  const COMPOSITE = 'compositeOracle'

  const ensAddress = new Map([
    [1, '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72'],
    [42, '0xA24b97c7617cc40dCc122F6dF813584A604a6C28'],
  ]) // https://ens.mirror.xyz/5cGl-Y37aTxtokdWk21qlULmE1aSM_NuX9fstbOPoWU
  
  // Input data: assetId, asset address
  const addedAssets: Array<[string, string]> = [
    [ENS, ensAddress.get(chainId) as string],
  ]
  // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
  const ilks: Array<[string, string, string, number, number, number, number, number]> = [
    [DAI, ENS, COMPOSITE, 1670000, 600000, 500000, 100, 18],
    [USDC, ENS, COMPOSITE, 1670000, 600000, 500000, 100, 6],
  ]
  // Input data: seriesId, [ilkId]
  const seriesIlks: Array<[string, string[]]> = [
    [stringToBytes6('0104'), [ENS]],
    [stringToBytes6('0105'), [ENS]],
    [stringToBytes6('0204'), [ENS]],
    [stringToBytes6('0205'), [ENS]],
  ]
```
# Testing
The change has been tested on a mainnet fork by posting ENS to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/blob/54f94d6c8bf94ebf0e0a060a425c7a63bd8c113c/scripts/operations/governance/addCompositeCollateral/addENS.test.ts).
```
$ npx hardhat run --network localhost scripts/operations/governance/addCompositeCollateral/addENS.test.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
65532017200000000000000000 ENS available
series: 0x303130340000
vault: 0x11000df708d0c0ce84929b99
posted and borrowed
repaid and withdrawn
series: 0x303130350000
vault: 0x48a84506528015d548819131
posted and borrowed
repaid and withdrawn
series: 0x303230340000
vault: 0x9433ee0ef41c983b6ee795b0
posted and borrowed
repaid and withdrawn
series: 0x303230350000
vault: 0x749cff617e7cd873f1897420
posted and borrowed
repaid and withdrawn
```