### PR TITLE
Add UNI as a collateral

### DIFF
--- a/YPP-0015.md
+++ b/YPP-0015.md
@@ -4,100 +4,79 @@ Enable UNI as a collateral for DAI and USDC
 # Background
 UNI has a $9,697M market cap and 287K holders.
 
-To enable UNI as a collateral we will be using the UNI/ETH chainlink price feed as a source of price data. 
+To enable UNI as a collateral we will be using the UNI/ETH chainlink price feed as a source of price data.
 
 # Details
 
-**1. Add UNI as an asset using the Wand**
-
-The [addUNI-1.ts](https://github.com/yieldprotocol/environments-v2/blob/ops/add-uni-collateral/scripts/operations/governance/addSimpleCollateral/addUNI-1.ts) script will be used, with this input:
+The [addChainlinkCollateral-1.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-1.ts) and [addChainlinkCollateral-2.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-2.ts) scripts  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addUNI.config.ts):
 
 ```
-  const uniAddress = new Map([
-    [1, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
-    [42, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
-  ]) // https://github.com/Uniswap/v3-periphery/blob/main/deploys.md
+export const assets: Map<number, Map<string, string>> = new Map([
+  [1, new Map([
+    [ETH,    '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+    [DAI,    '0x6B175474E89094C44Da98b954EedeAC495271d0F'],
+    [USDC,   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'],
+    [UNI,    '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
+  ])],
+])
   
-  const addedAssets: Array<[string, string]> = [[UNI, uniAddress.get(chainId) as string]]
 
+export const chainlinkSources: Map<number, Array<[string, string, string, string, string]>> = new Map([
+  [1, [
+    [UNI,   (assets.get(1) as Map<string, string>).get(UNI)   as string, ETH, (assets.get(1) as Map<string, string>).get(ETH) as string, '0xD6aA3D25116d8dA79Ea0246c4826EB951872e02e'],
+  ]],
+])
+
+// Assets for which we will have a Join
+export const assetToAdd: Map<number, [string, string]> = new Map([
+  [1,  [UNI, (assets.get(1) as Map<string, string>).get(UNI) as string]],
+])
+
+// Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
+export const limits: Array<[string, string, string, number, number, number, number, number]> = [
+  [DAI, UNI, CHAINLINK, 1670000, 1000000, 1000000, 5000, 18],
+  [USDC, UNI, CHAINLINK, 1670000, 1000000, 1000000, 5000, 6],
+]
+
+// Input data: seriesId, [ilkId]
+export const seriesIlks: Array<[string, string[]]> = [
+  [FYDAI2112,  [UNI]],
+  [FYDAI2203,  [UNI]],
+  [FYUSDC2112, [UNI]],
+  [FYUSDC2203, [UNI]],
+]
 ```
 
-**2. Configure the protocol**
+1. Deploy a Join for UNI using the Wand
+2. Orchestrate and configure oracles
+3. Permission the UNIJoin
+4. Make UNI into an Ilk
+5. Approve UNI as collateral for all series
 
-The rest of the configuration will be condUNIed into a single proposal with the [addUNI-2.ts](https://github.com/yieldprotocol/environments-v2/blob/ops/add-uni-collateral/scripts/operations/governance/addSimpleCollateral/addUNI-2.ts) script, which includes these actions:
-
-1. Orchestrate and configure oracles
-2. Permission the UNIJoin
-3. Make UNI into an Ilk
-4. Approve UNI as collateral for all series
-
-And these inputs:
-```
-  const CHAINLINK = 'chainlinkOracle'
-
-  const uniAddress = new Map([
-    [1, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
-    [42, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
-  ]) // https://github.com/Uniswap/v3-periphery/blob/main/deploys.md
-
-  const uniOracleAddress = new Map([
-    [1, '0xD6aA3D25116d8dA79Ea0246c4826EB951872e02e'],
-  ]) // https://docs.chain.link/docs/ethereum-addresses/
-
-  const wethAddress = new Map([
-    [1, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
-    [42, '0x55C0458edF1D8E07DF9FB44B8960AecC515B4492'],
-  ]) // From assets.json in addresses archive
-
-  // Input data: baseId, base address, quoteId, quote address, oracle name, source address
-  const uniEthSource: Array<[string, string, string, string, string, string]> = [
-    [
-      UNI,
-      uniAddress.get(chainId) as string,
-      ETH,
-      wethAddress.get(chainId) as string,
-      CHAINLINK,
-      uniOracleAddress.get(chainId) as string,
-    ],
-  ]
-  
-  // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
-  const ilks: Array<[string, string, string, number, number, number, number, number]> = [
-    [DAI, UNI, CHAINLINK, 2000000, 500000, 250000, 100, 18],
-    [USDC, UNI, CHAINLINK, 2000000, 500000, 250000, 100, 6],
-  ]
-  // Input data: seriesId, [ilkId]
-  const seriesIlks: Array<[string, string[]]> = [
-    [stringToBytes6('0104'), [UNI]],
-    [stringToBytes6('0105'), [UNI]],
-    [stringToBytes6('0204'), [UNI]],
-    [stringToBytes6('0205'), [UNI]],
-  ]
 ```
 # Testing
-The change has been tested on a mainnet fork by posting UNI to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/blob/ops/add-uni-collateral/scripts/operations/governance/addSimpleCollateral/addUNI.test.ts).
+The change has been tested on a mainnet fork by posting UNI to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/tree/feat/add-chainlink-collateral/scripts/governance/addChainlinkCollateral/addChainlinkCollateral.test.ts).
 ```
-laptop:environments-v2 praffulsahu$ sudo npx hardhat run --network localhost scripts/operations/governance/addSimpleCollateral/addUNI.test.ts 
-Password:
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/addChainlinkCollateral/addChainlinkCollateral.test.ts 
 Creating Typechain artifacts in directory typechain for target ethers-v5
 Successfully generated Typechain artifacts!
 ChainId: 1
 Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
 24679867136918000000000000 UNI available
 series: 0x303130340000
-vault: 0x45202a65bfcd7ab3f0151616
+vault: 0x1d25679657c550a823332384
 posted and borrowed
 repaid and withdrawn
 series: 0x303130350000
-vault: 0x27383ffb82d53005d85bfe6f
+vault: 0x9f888385ed574463c9e909e5
 posted and borrowed
 repaid and withdrawn
 series: 0x303230340000
-vault: 0x884670a256bd7b4af9c7ff27
+vault: 0x6b5f6b084071e62665bc8352
 posted and borrowed
 repaid and withdrawn
 series: 0x303230350000
-vault: 0x38c5c682deb3af36e399556d
+vault: 0xfde5d42a23ef18623d39c152
 posted and borrowed
 repaid and withdrawn
 

--- a/YPP-0015.md
+++ b/YPP-0015.md
@@ -1,0 +1,104 @@
+# Proposal
+Enable UNI as a collateral for DAI and USDC
+
+# Background
+UNI has a $9,697M market cap and 287K holders.
+
+To enable UNI as a collateral we will be using the UNI/ETH chainlink price feed as a source of price data. 
+
+# Details
+
+**1. Add UNI as an asset using the Wand**
+
+The [addUNI-1.ts](https://github.com/yieldprotocol/environments-v2/blob/ops/add-uni-collateral/scripts/operations/governance/addSimpleCollateral/addUNI-1.ts) script will be used, with this input:
+
+```
+  const uniAddress = new Map([
+    [1, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
+    [42, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
+  ]) // https://github.com/Uniswap/v3-periphery/blob/main/deploys.md
+  
+  const addedAssets: Array<[string, string]> = [[UNI, uniAddress.get(chainId) as string]]
+
+```
+
+**2. Configure the protocol**
+
+The rest of the configuration will be condUNIed into a single proposal with the [addUNI-2.ts](https://github.com/yieldprotocol/environments-v2/blob/ops/add-uni-collateral/scripts/operations/governance/addSimpleCollateral/addUNI-2.ts) script, which includes these actions:
+
+1. Orchestrate and configure oracles
+2. Permission the UNIJoin
+3. Make UNI into an Ilk
+4. Approve UNI as collateral for all series
+
+And these inputs:
+```
+  const CHAINLINK = 'chainlinkOracle'
+
+  const uniAddress = new Map([
+    [1, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
+    [42, '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
+  ]) // https://github.com/Uniswap/v3-periphery/blob/main/deploys.md
+
+  const uniOracleAddress = new Map([
+    [1, '0xD6aA3D25116d8dA79Ea0246c4826EB951872e02e'],
+  ]) // https://docs.chain.link/docs/ethereum-addresses/
+
+  const wethAddress = new Map([
+    [1, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+    [42, '0x55C0458edF1D8E07DF9FB44B8960AecC515B4492'],
+  ]) // From assets.json in addresses archive
+
+  // Input data: baseId, base address, quoteId, quote address, oracle name, source address
+  const uniEthSource: Array<[string, string, string, string, string, string]> = [
+    [
+      UNI,
+      uniAddress.get(chainId) as string,
+      ETH,
+      wethAddress.get(chainId) as string,
+      CHAINLINK,
+      uniOracleAddress.get(chainId) as string,
+    ],
+  ]
+  
+  // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
+  const ilks: Array<[string, string, string, number, number, number, number, number]> = [
+    [DAI, UNI, CHAINLINK, 2000000, 500000, 250000, 100, 18],
+    [USDC, UNI, CHAINLINK, 2000000, 500000, 250000, 100, 6],
+  ]
+  // Input data: seriesId, [ilkId]
+  const seriesIlks: Array<[string, string[]]> = [
+    [stringToBytes6('0104'), [UNI]],
+    [stringToBytes6('0105'), [UNI]],
+    [stringToBytes6('0204'), [UNI]],
+    [stringToBytes6('0205'), [UNI]],
+  ]
+```
+# Testing
+The change has been tested on a mainnet fork by posting UNI to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/blob/ops/add-uni-collateral/scripts/operations/governance/addSimpleCollateral/addUNI.test.ts).
+```
+laptop:environments-v2 praffulsahu$ sudo npx hardhat run --network localhost scripts/operations/governance/addSimpleCollateral/addUNI.test.ts 
+Password:
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+24679867136918000000000000 UNI available
+series: 0x303130340000
+vault: 0x45202a65bfcd7ab3f0151616
+posted and borrowed
+repaid and withdrawn
+series: 0x303130350000
+vault: 0x27383ffb82d53005d85bfe6f
+posted and borrowed
+repaid and withdrawn
+series: 0x303230340000
+vault: 0x884670a256bd7b4af9c7ff27
+posted and borrowed
+repaid and withdrawn
+series: 0x303230350000
+vault: 0x38c5c682deb3af36e399556d
+posted and borrowed
+repaid and withdrawn
+
+```

--- a/YPP-0015.md
+++ b/YPP-0015.md
@@ -34,8 +34,8 @@ export const assetToAdd: Map<number, [string, string]> = new Map([
 
 // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
 export const limits: Array<[string, string, string, number, number, number, number, number]> = [
-  [DAI, UNI, CHAINLINK, 1670000, 1000000, 1000000, 5000, 18],
-  [USDC, UNI, CHAINLINK, 1670000, 1000000, 1000000, 5000, 6],
+  [DAI, UNI, CHAINLINK, 1670000, 600000, 1000000, 5000, 18],
+  [USDC, UNI, CHAINLINK, 1670000, 600000, 1000000, 5000, 6],
 ]
 
 // Input data: seriesId, [ilkId]

--- a/YPP-0015.md
+++ b/YPP-0015.md
@@ -8,7 +8,7 @@ To enable UNI as a collateral we will be using the UNI/ETH chainlink price feed 
 
 # Details
 
-The [addChainlinkCollateral-1.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-1.ts) and [addChainlinkCollateral-2.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-2.ts) scripts  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addUNI.config.ts):
+The [addChainlinkCollateral-1.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-1.ts) and [addChainlinkCollateral-2.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-2.ts) scripts  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/594622bb3b8442841c1ae1cd6b82d0cd5f3d242f/scripts/governance/addChainlinkCollateral/addUNI.config.ts):
 
 ```
 export const assets: Map<number, Map<string, string>> = new Map([


### PR DESCRIPTION
# Proposal
Enable UNI as a collateral for DAI and USDC

# Background
UNI has a $9,697M market cap and 287K holders.

To enable UNI as a collateral we will be using the UNI/ETH chainlink price feed as a source of price data.

# Details

The [addChainlinkCollateral-1.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-1.ts) and [addChainlinkCollateral-2.ts](https://github.com/yieldprotocol/environments-v2/blob/c46522044eff41e3d708f11e4f172c4edf80dbae/scripts/governance/addChainlinkCollateral/addChainlinkCollateral-2.ts) scripts  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/594622bb3b8442841c1ae1cd6b82d0cd5f3d242f/scripts/governance/addChainlinkCollateral/addUNI.config.ts):

```
export const assets: Map<number, Map<string, string>> = new Map([
  [1, new Map([
    [ETH,    '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
    [DAI,    '0x6B175474E89094C44Da98b954EedeAC495271d0F'],
    [USDC,   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'],
    [UNI,    '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'],
  ])],
])
  

export const chainlinkSources: Map<number, Array<[string, string, string, string, string]>> = new Map([
  [1, [
    [UNI,   (assets.get(1) as Map<string, string>).get(UNI)   as string, ETH, (assets.get(1) as Map<string, string>).get(ETH) as string, '0xD6aA3D25116d8dA79Ea0246c4826EB951872e02e'],
  ]],
])

// Assets for which we will have a Join
export const assetToAdd: Map<number, [string, string]> = new Map([
  [1,  [UNI, (assets.get(1) as Map<string, string>).get(UNI) as string]],
])

// Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), inv(ratio), line, dust, dec
export const limits: Array<[string, string, string, number, number, number, number, number]> = [
  [DAI, UNI, CHAINLINK, 1670000, 600000, 1000000, 5000, 18],
  [USDC, UNI, CHAINLINK, 1670000, 600000, 1000000, 5000, 6],
]

// Input data: seriesId, [ilkId]
export const seriesIlks: Array<[string, string[]]> = [
  [FYDAI2112,  [UNI]],
  [FYDAI2203,  [UNI]],
  [FYUSDC2112, [UNI]],
  [FYUSDC2203, [UNI]],
]
```

1. Deploy a Join for UNI using the Wand
2. Orchestrate and configure oracles
3. Permission the UNIJoin
4. Make UNI into an Ilk
5. Approve UNI as collateral for all series

```
# Testing
The change has been tested on a mainnet fork by posting UNI to all series, borrowing, repaying and wthdrawing. [Script](https://github.com/yieldprotocol/environments-v2/tree/feat/add-chainlink-collateral/scripts/governance/addChainlinkCollateral/addChainlinkCollateral.test.ts).
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/addChainlinkCollateral/addChainlinkCollateral.test.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
24679867136918000000000000 UNI available
series: 0x303130340000
vault: 0x1d25679657c550a823332384
posted and borrowed
repaid and withdrawn
series: 0x303130350000
vault: 0x9f888385ed574463c9e909e5
posted and borrowed
repaid and withdrawn
series: 0x303230340000
vault: 0x6b5f6b084071e62665bc8352
posted and borrowed
repaid and withdrawn
series: 0x303230350000
vault: 0xfde5d42a23ef18623d39c152
posted and borrowed
repaid and withdrawn

```