### PR TITLE
Raise the USDC/ETH ceiling to $5M

### DIFF
--- a/YPP-0017.md
+++ b/YPP-0017.md
@@ -1,0 +1,50 @@
+# Proposal
+Raise the ceiling level for USDC/ETH to 5000000
+
+# Background
+The ceiling (max debt) level for USDC borrowing with ENS collateral is set to 1,000,000 currently, while the total borrowed amount for that pair is 805,700.06.
+
+# Details
+The [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) script will be used, with this input:
+```
+// Input data: baseId, ilkId, maxDebt
+export const newMax: Array<[string, string, number]> = [
+  [USDC, ETH, 5000000],
+]
+
+```
+# Testing
+The change has been tested on a mainnet fork by running [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) first followed by [updateCeiling.test.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.test.ts) to verify that the changes were made.
+```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00: 1000000 -> 5000000
+Proposal: 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
+Proposed 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00: 1000000 -> 5000000
+Proposal: 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
+Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
+Approved 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00: 1000000 -> 5000000
+Proposal: 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
+Executed 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.test.ts 
+Creating Typechain artifacts in directory typechain for target ethers-v5
+Successfully generated Typechain artifacts!
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+02/00 set: 5000000
+```


### PR DESCRIPTION
# Proposal
Raise the ceiling level for USDC/ETH to 5000000

# Background
The ceiling (max debt) level for USDC borrowing with ENS collateral is set to 1,000,000 currently, while the total borrowed amount for that pair is 805,700.06.

# Details
The [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) script will be used, with this input:
```
// Input data: baseId, ilkId, maxDebt
export const newMax: Array<[string, string, number]> = [
  [USDC, ETH, 5000000],
]

```
# Testing
The change has been tested on a mainnet fork by running [updateCeiling.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.ts) first followed by [updateCeiling.test.ts](https://github.com/yieldprotocol/environments-v2/blob/feat/update-ceiling/scripts/operations/governance/updateCeiling/updateCeiling.test.ts) to verify that the changes were made.
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00: 1000000 -> 5000000
Proposal: 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
Proposed 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00: 1000000 -> 5000000
Proposal: 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
Approved 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00: 1000000 -> 5000000
Proposal: 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
Executed 0x95ef8868b7fffd5d983d750fb570bd81a0652fe960ee7739dc6a2efa3ad8550a
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateCeiling/updateCeiling.test.ts 
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
02/00 set: 5000000
```