### PR TITLE
Set the initial offer for LINK to 60%

### DIFF
--- a/YPP-0022.md
+++ b/YPP-0022.md
@@ -1,0 +1,50 @@
+# Proposal
+Set the initial offer for LINK to 60%
+
+# Background
+On the activation of LINK as a collateral, the initial offer for liquidation auctions was incorrectly set to 100%. The impact is that on LINK liquidations, the vault is always offered at the minimum price.
+
+# Details
+The [updateInitialOffer.ts](https://github.com/yieldprotocol/environments-v2/blob/bb7996d3866fd46ac2203ebb4574e6aa69b3505b/scripts/governance/updateInitialOffer/updateInitialOffer.ts) script will be used, with this input:
+```
+export const newInitialOffer: Array<[string, number]> = [
+  [LINK, 600000],
+]
+```
+# Testing
+The change has been tested on a mainnet fork by running [updateInitialOffer.ts](https://github.com/yieldprotocol/environments-v2/blob/bb7996d3866fd46ac2203ebb4574e6aa69b3505b/scripts/governance/updateInitialOffer/updateInitialOffer.ts) first followed by [updateInitialOffer.test.ts](https://github.com/yieldprotocol/environments-v2/blob/bb7996d3866fd46ac2203ebb4574e6aa69b3505b/scripts/governance/updateInitialOffer/updateInitialOffer.test.ts) to verify that the changes were made.
+```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.test.ts 
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+06 not updated, still at 1000000
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.ts 
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+06: 1000000 -> 600000
+Proposal: 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
+Proposed 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.ts 
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+06: 1000000 -> 600000
+Proposal: 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
+Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
+Approved 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.ts 
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+06: 1000000 -> 600000
+Proposal: 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
+Executed 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.test.ts 
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+06 set: 600000
+
+```


### PR DESCRIPTION
# Proposal
Set the initial offer for LINK to 60%

# Background
On the activation of LINK as a collateral, the initial offer for liquidation auctions was incorrectly set to 100%. The impact is that on LINK liquidations, the vault is always offered at the minimum price.

# Details
The [updateInitialOffer.ts](https://github.com/yieldprotocol/environments-v2/blob/bb7996d3866fd46ac2203ebb4574e6aa69b3505b/scripts/governance/updateInitialOffer/updateInitialOffer.ts) script will be used, with this input:
```
export const newInitialOffer: Array<[string, number]> = [
  [LINK, 600000],
]
```
# Testing
The change has been tested on a mainnet fork by running [updateInitialOffer.ts](https://github.com/yieldprotocol/environments-v2/blob/bb7996d3866fd46ac2203ebb4574e6aa69b3505b/scripts/governance/updateInitialOffer/updateInitialOffer.ts) first followed by [updateInitialOffer.test.ts](https://github.com/yieldprotocol/environments-v2/blob/bb7996d3866fd46ac2203ebb4574e6aa69b3505b/scripts/governance/updateInitialOffer/updateInitialOffer.test.ts) to verify that the changes were made.
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.test.ts 
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
06 not updated, still at 1000000
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.ts 
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
06: 1000000 -> 600000
Proposal: 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
Proposed 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.ts 
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
06: 1000000 -> 600000
Proposal: 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
Approved 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.ts 
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
06: 1000000 -> 600000
Proposal: 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
Executed 0x21b9c51b57de245f0a5051837931e2e52a90b6ada03bd3d25a1091abc0a31544
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateInitialOffer/updateInitialOffer.test.ts 
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
06 set: 600000

```