### PR TITLE
Give Richie and Prafful developer roles

### DIFF
--- a/YPP-0023.md
+++ b/YPP-0023.md
@@ -1,0 +1,16 @@
+# Proposal
+Give developer roles to 0x06FB6f89eAA936d4Cfe58FfA071cf8EAe17ac9AB, controlled by @iamsahu, and 0xfe90d993367bc93D171A5ED88ab460759DE2bED6, controlled by @devtooligan
+
+# Background
+The only account actively proposing and excuting proposals is @alcueca, and that poses a centralizaton risk in knowledge terms, and a bottleneck in governance. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
+
+# Details
+
+The (addDevelopers)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/addDevelopers/addDevelopers.ts] script will be used, with (this input)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/addDevelopers/addDevelopers.mainnet.config.ts].
+
+```
+export const newDevelopers: string[] = [
+    '0x06FB6f89eAA936d4Cfe58FfA071cf8EAe17ac9AB',
+    '0xfe90d993367bc93D171A5ED88ab460759DE2bED6'
+]
+```


### PR DESCRIPTION
# Proposal
Give developer roles to 0x06FB6f89eAA936d4Cfe58FfA071cf8EAe17ac9AB, controlled by @iamsahu, and 0xfe90d993367bc93D171A5ED88ab460759DE2bED6, controlled by @devtooligan

# Background
The only account actively proposing and excuting proposals is @alcueca, and that poses a centralizaton risk in knowledge terms, and a bottleneck in governance. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.

# Details

The (addDevelopers)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/addDevelopers/addDevelopers.ts] script will be used, with (this input)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/addDevelopers/addDevelopers.mainnet.config.ts].

```
export const newDevelopers: string[] = [
    '0x06FB6f89eAA936d4Cfe58FfA071cf8EAe17ac9AB',
    '0xfe90d993367bc93D171A5ED88ab460759DE2bED6'
]
```