### PR TITLE
Deploy June 2022 fyToken and pools

### DIFF
--- a/YPP-0025.md
+++ b/YPP-0025.md
@@ -11,37 +11,50 @@ This deployment is an intermediate step as well in decommissioning the Wand and 
 The [deployJuneSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/deployJuneSeries.mainnet.sh) script  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/addJuneSeries.mainnet.config.ts):
 
 ```
+// Parameters to deploy fyToken with
 // seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
 export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
   [FYDAI2206,  DAI,  protocol.get(COMPOUND) as string, joins.get(DAI) as string,  EOJUN22, 'FYDAI2206',  'FYDAI2206'],
   [FYUSDC2206, USDC, protocol.get(COMPOUND) as string, joins.get(USDC) as string, EOJUN22, 'FYUSDC2206', 'FYUSDC2206'],
 ]
 
-// seriesId, fyTokenAddress
-export const poolData: Array<[string, string]> = [
-  [FYDAI2206,  fyTokens.get(FYDAI2206) as string],
-  [FYUSDC2206, fyTokens.get(FYUSDC2206) as string]
-]
-
+// Pool fees to be set in the PoolFactory prior to pool deployment
 // g1, g2
 export const poolFees: [BigNumber, BigNumber] = [
   ONE64.mul(75).div(100), // Sell base to the pool
   ONE64.mul(100).div(75), // Sell fyToken to the pool
 ]
+
+// Time stretch to be set in the PoolFactory prior to pool deployment
+export const timeStretch: BigNumber = ONE64.div(secondsIn25Years)
+
+
+// Pool fees to be set in the PoolFactory prior to pool deployment
+// g1, g2
+export const poolFees: [BigNumber, BigNumber] = [
+  ONE64.mul(75).div(100), // Sell base to the pool
+  ONE64.mul(100).div(75), // Sell fyToken to the pool
+]
+
+// Time stretch to be set in the PoolFactory prior to pool deployment
+export const timeStretch: BigNumber = ONE64.div(secondsIn25Years)
+
 ```
 
-The steps taken are four:
+The steps taken are five:
 1. Deploy fyToken contracts
 2. Set pool fees in PoolFactory
-3. Permission the PoolFactory for the Timelock to be able to create pools
-4. Deploy pool contracts
+3. Set time stretch in the PoolFactory
+4. Permission the PoolFactory for the Timelock to be able to create pools
+5. Deploy pool contracts
 
 ```
 # Testing
 The change has been deployed on a mainnet fork with the following output.
 ```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ ./scripts/governance/addSeries/addJuneSeries/addJuneSeries.localhost.sh 
 + RUN='npx hardhat run --network localhost'
-++ dirname ./scripts/governance/addSeries/addJuneSeries/deployJuneSeries.mainnet.sh
+++ dirname ./scripts/governance/addSeries/addJuneSeries/addJuneSeries.localhost.sh
 + HERE=./scripts/governance/addSeries/addJuneSeries
 + npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-1.ts
 No need to generate any newer typings.
@@ -49,43 +62,40 @@ ChainId: 1
 Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
 Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303130360000
 Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303130360000
-FYToken deployed at 0xA4899D35897033b927acFCf422bc745916139776
-npx hardhat verify --network localhost 0xA4899D35897033b927acFCf422bc745916139776 0x303100000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc 1656039600 FYDAI2206 FYDAI2206 --libraries safeERC20Namer.js
+FYToken deployed at 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3
+npx hardhat verify --network localhost 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3 0x303100000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc 1656039600 FYDAI2206 FYDAI2206 --libraries safeERC20Namer.js
 fyToken.grantRoles(ROOT, timelock)
 Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303230360000
 Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303230360000
-FYToken deployed at 0xAA292E8611aDF267e563f334Ee42320aC96D0463
-npx hardhat verify --network localhost 0xAA292E8611aDF267e563f334Ee42320aC96D0463 0x303200000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 1656039600 FYUSDC2206 FYUSDC2206 --libraries safeERC20Namer.js
+FYToken deployed at 0x5067457698Fd6Fa1C6964e416b3f42713513B3dD
+npx hardhat verify --network localhost 0x5067457698Fd6Fa1C6964e416b3f42713513B3dD 0x303200000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 1656039600 FYUSDC2206 FYUSDC2206 --libraries safeERC20Namer.js
 fyToken.grantRoles(ROOT, timelock)
-+ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
-[...]
-+ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
-[...]
 + npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
 No need to generate any newer typings.
 ChainId: 1
 Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
 g1 set to 13835058055282163712
 g2 set to 24595658764946068821
+ts set to 23381681843
 poolFactory.grantRoles(gov, timelock)
 poolFactory.grantRole(ROOT, cloak)
 poolFactory.revokeRole(ROOT, deployer)
-Using join at 0xA4899D35897033b927acFCf422bc745916139776 for 0x303130360000
-Using join at 0xAA292E8611aDF267e563f334Ee42320aC96D0463 for 0x303230360000
-Proposal: 0xb9d4c21b699ed59acc9489edeb151e091b6b74fac0607861afb585cb7c359264
-Executed 0xb9d4c21b699ed59acc9489edeb151e091b6b74fac0607861afb585cb7c359264
-Using join at 0xA4899D35897033b927acFCf422bc745916139776 for 0x303130360000
-Pool deployed at 0x2294ef247800d0054aE2eC9E73955e54d18Ae716
-npx hardhat verify --network localhost 0x2294ef247800d0054aE2eC9E73955e54d18Ae716  --libraries safeERC20Namer.js
-Using join at 0xAA292E8611aDF267e563f334Ee42320aC96D0463 for 0x303230360000
-Pool deployed at 0x1E390C5862a67cCd6E2F805bCcE59c76E09B4191
-npx hardhat verify --network localhost 0x1E390C5862a67cCd6E2F805bCcE59c76E09B4191  --libraries safeERC20Namer.js
+Using join at 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3 for 0x303130360000
+Using join at 0x5067457698Fd6Fa1C6964e416b3f42713513B3dD for 0x303230360000
+Proposal: 0xddb6d79987dff4bf5c83c8c7ceaf8d8846070f31429d1a7ffa661d86723fa19a
+Proposed 0xddb6d79987dff4bf5c83c8c7ceaf8d8846070f31429d1a7ffa661d86723fa19a
+
 ```
 
 The g1 and g2 values being set are as follows:
 ```
 g1 set to 13835058055282163712
 g2 set to 24595658764946068821
+```
+
+The ts value being set are as follows:
+```
+ts set to 23381681843
 ```
 
 To convert the values from 64.64 to decimal, the [ABDK converter](https://toolkit.abdk.consulting/math#convert-number) can be used.

--- a/YPP-0025.md
+++ b/YPP-0025.md
@@ -1,0 +1,91 @@
+# Proposal
+Deploy the fyToken and pool contracts for the DAI and USDC June series
+
+# Background
+On December 31st 2021 the FYDAI2112 and FYUSDC2112 series will mature, and the YSDAI6MJD and YSUSDC6MJD strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled.
+
+# Details
+
+This deployment is an intermediate step as well in decommissioning the Wand and Factories. While the FYTokenFactory doesn't need to be used, to deploy the Pools without the PoolFactory would require a refactor of the Pool constructor which is beyond the risk apettite at this point. For this reason, we are premissioning the Timelock to deploy the Pools using the PoolFactory, in the way that the Wand would do it.
+
+The [deployJuneSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/deployJuneSeries.mainnet.sh) script  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/addJuneSeries.mainnet.config.ts):
+
+```
+// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
+export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
+  [FYDAI2206,  DAI,  protocol.get(COMPOUND) as string, joins.get(DAI) as string,  EOJUN22, 'FYDAI2206',  'FYDAI2206'],
+  [FYUSDC2206, USDC, protocol.get(COMPOUND) as string, joins.get(USDC) as string, EOJUN22, 'FYUSDC2206', 'FYUSDC2206'],
+]
+
+// seriesId, fyTokenAddress
+export const poolData: Array<[string, string]> = [
+  [FYDAI2206,  fyTokens.get(FYDAI2206) as string],
+  [FYUSDC2206, fyTokens.get(FYUSDC2206) as string]
+]
+
+// g1, g2
+export const poolFees: [BigNumber, BigNumber] = [
+  ONE64.mul(75).div(100), // Sell base to the pool
+  ONE64.mul(100).div(75), // Sell fyToken to the pool
+]
+```
+
+The steps taken are four:
+1. Deploy fyToken contracts
+2. Set pool fees in PoolFactory
+3. Permission the PoolFactory for the Timelock to be able to create pools
+4. Deploy pool contracts
+
+```
+# Testing
+The change has been deployed on a mainnet fork with the following output.
+```
++ RUN='npx hardhat run --network localhost'
+++ dirname ./scripts/governance/addSeries/addJuneSeries/deployJuneSeries.mainnet.sh
++ HERE=./scripts/governance/addSeries/addJuneSeries
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-1.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303130360000
+Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303130360000
+FYToken deployed at 0xA4899D35897033b927acFCf422bc745916139776
+npx hardhat verify --network localhost 0xA4899D35897033b927acFCf422bc745916139776 0x303100000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc 1656039600 FYDAI2206 FYDAI2206 --libraries safeERC20Namer.js
+fyToken.grantRoles(ROOT, timelock)
+Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303230360000
+Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303230360000
+FYToken deployed at 0xAA292E8611aDF267e563f334Ee42320aC96D0463
+npx hardhat verify --network localhost 0xAA292E8611aDF267e563f334Ee42320aC96D0463 0x303200000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 1656039600 FYUSDC2206 FYUSDC2206 --libraries safeERC20Namer.js
+fyToken.grantRoles(ROOT, timelock)
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
+[...]
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
+[...]
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+g1 set to 13835058055282163712
+g2 set to 24595658764946068821
+poolFactory.grantRoles(gov, timelock)
+poolFactory.grantRole(ROOT, cloak)
+poolFactory.revokeRole(ROOT, deployer)
+Using join at 0xA4899D35897033b927acFCf422bc745916139776 for 0x303130360000
+Using join at 0xAA292E8611aDF267e563f334Ee42320aC96D0463 for 0x303230360000
+Proposal: 0xb9d4c21b699ed59acc9489edeb151e091b6b74fac0607861afb585cb7c359264
+Executed 0xb9d4c21b699ed59acc9489edeb151e091b6b74fac0607861afb585cb7c359264
+Using join at 0xA4899D35897033b927acFCf422bc745916139776 for 0x303130360000
+Pool deployed at 0x2294ef247800d0054aE2eC9E73955e54d18Ae716
+npx hardhat verify --network localhost 0x2294ef247800d0054aE2eC9E73955e54d18Ae716  --libraries safeERC20Namer.js
+Using join at 0xAA292E8611aDF267e563f334Ee42320aC96D0463 for 0x303230360000
+Pool deployed at 0x1E390C5862a67cCd6E2F805bCcE59c76E09B4191
+npx hardhat verify --network localhost 0x1E390C5862a67cCd6E2F805bCcE59c76E09B4191  --libraries safeERC20Namer.js
+```
+
+The g1 and g2 values being set are as follows:
+```
+g1 set to 13835058055282163712
+g2 set to 24595658764946068821
+```
+
+To convert the values from 64.64 to decimal, the [ABDK converter](https://toolkit.abdk.consulting/math#convert-number) can be used.


### PR DESCRIPTION
# Proposal
Deploy the fyToken and pool contracts for the DAI and USDC June series

# Background
On December 31st 2021 the FYDAI2112 and FYUSDC2112 series will mature, and the YSDAI6MJD and YSUSDC6MJD strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled.

# Details

This deployment is an intermediate step as well in decommissioning the Wand and Factories. While the FYTokenFactory doesn't need to be used, to deploy the Pools without the PoolFactory would require a refactor of the Pool constructor which is beyond the risk apettite at this point. For this reason, we are premissioning the Timelock to deploy the Pools using the PoolFactory, in the way that the Wand would do it.

The [deployJuneSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/deployJuneSeries.mainnet.sh) script  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/addJuneSeries.mainnet.config.ts):

```
// Parameters to deploy fyToken with
// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
  [FYDAI2206,  DAI,  protocol.get(COMPOUND) as string, joins.get(DAI) as string,  EOJUN22, 'FYDAI2206',  'FYDAI2206'],
  [FYUSDC2206, USDC, protocol.get(COMPOUND) as string, joins.get(USDC) as string, EOJUN22, 'FYUSDC2206', 'FYUSDC2206'],
]

// Pool fees to be set in the PoolFactory prior to pool deployment
// g1, g2
export const poolFees: [BigNumber, BigNumber] = [
  ONE64.mul(75).div(100), // Sell base to the pool
  ONE64.mul(100).div(75), // Sell fyToken to the pool
]

// Time stretch to be set in the PoolFactory prior to pool deployment
export const timeStretch: BigNumber = ONE64.div(secondsIn25Years)


// Pool fees to be set in the PoolFactory prior to pool deployment
// g1, g2
export const poolFees: [BigNumber, BigNumber] = [
  ONE64.mul(75).div(100), // Sell base to the pool
  ONE64.mul(100).div(75), // Sell fyToken to the pool
]

// Time stretch to be set in the PoolFactory prior to pool deployment
export const timeStretch: BigNumber = ONE64.div(secondsIn25Years)

```

The steps taken are five:
1. Deploy fyToken contracts
2. Set pool fees in PoolFactory
3. Set time stretch in the PoolFactory
4. Permission the PoolFactory for the Timelock to be able to create pools
5. Deploy pool contracts

# Testing
The change has been deployed on a mainnet fork with the following output.
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ ./scripts/governance/addSeries/addJuneSeries/addJuneSeries.localhost.sh 
+ RUN='npx hardhat run --network localhost'
++ dirname ./scripts/governance/addSeries/addJuneSeries/addJuneSeries.localhost.sh
+ HERE=./scripts/governance/addSeries/addJuneSeries
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-1.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303130360000
Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303130360000
FYToken deployed at 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3
npx hardhat verify --network localhost 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3 0x303100000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc 1656039600 FYDAI2206 FYDAI2206 --libraries safeERC20Namer.js
fyToken.grantRoles(ROOT, timelock)
Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303230360000
Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303230360000
FYToken deployed at 0x5067457698Fd6Fa1C6964e416b3f42713513B3dD
npx hardhat verify --network localhost 0x5067457698Fd6Fa1C6964e416b3f42713513B3dD 0x303200000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 1656039600 FYUSDC2206 FYUSDC2206 --libraries safeERC20Namer.js
fyToken.grantRoles(ROOT, timelock)
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-2.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
g1 set to 13835058055282163712
g2 set to 24595658764946068821
ts set to 23381681843
poolFactory.grantRoles(gov, timelock)
poolFactory.grantRole(ROOT, cloak)
poolFactory.revokeRole(ROOT, deployer)
Using join at 0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3 for 0x303130360000
Using join at 0x5067457698Fd6Fa1C6964e416b3f42713513B3dD for 0x303230360000
Proposal: 0xddb6d79987dff4bf5c83c8c7ceaf8d8846070f31429d1a7ffa661d86723fa19a
Proposed 0xddb6d79987dff4bf5c83c8c7ceaf8d8846070f31429d1a7ffa661d86723fa19a

```

The g1 and g2 values being set are as follows:
```
g1 set to 13835058055282163712
g2 set to 24595658764946068821
```

The ts value being set are as follows:
```
ts set to 23381681843
```

To convert the values from 64.64 to decimal, the [ABDK converter](https://toolkit.abdk.consulting/math#convert-number) can be used.