### PR TITLE
Initialize June series, and roll strategies

### DIFF
--- a/YPP-0026.md
+++ b/YPP-0026.md
@@ -47,7 +47,6 @@ The steps taken are four:
 3. Initialize pools
 4. Roll strategies
 
-```
 # Testing
 The change has been deployed on a mainnet fork in which the time has been advanced to the December 31st maturity date.
 ```
@@ -100,16 +99,3 @@ Strategy YSUSDC6MJD rolled onto 0x303230360000
 Proposal: 0x1746c28b6cfffdba7f070aee2e7b8a555e7c8aac3cd63269e920a326e262ab92
 Executed 0x1746c28b6cfffdba7f070aee2e7b8a555e7c8aac3cd63269e920a326e262ab92
 ```
-
-The g1 and g2 values being set are as follows:
-```
-g1 set to 13835058055282163712
-g2 set to 24595658764946068821
-```
-
-The ts value being set are as follows:
-```
-ts set to 23381681843
-```
-
-To convert the values from 64.64 to decimal, the [ABDK converter](https://toolkit.abdk.consulting/math#convert-number) can be used.

--- a/YPP-0026.md
+++ b/YPP-0026.md
@@ -1,0 +1,115 @@
+# Proposal
+Initialize the fyToken and pool June contracts for the DAI and USDC June series.
+Rollover the *JD strategies to the June pool contracts.
+
+# Background
+On December 31st 2021 the FYDAI2112 and FYUSDC2112 series will mature, and the YSDAI6MJD and YSUSDC6MJD strategies will stop accruing fees. At that date, we will activate the June series for DAI and USDC, and roll the YSDAI6MJD and YSUSDC6MJD strategies to the June pool contracts to provide them with liquidity.
+
+# Details
+
+The [activateJuneSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/activateJuneSeries.mainnet.sh) script  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/addJuneSeries.mainnet.config.ts):
+
+At the time of submitting this proposal, both the DAI and USDC Joins have enough funds to serve the redemption of all the fyToken in de December series:
+ - Dai Join has 609886630292632589467107 DAI, pool has 6788019263610582280742 fyDAI. Surplus is 603098 611029022007186365 DAI
+ - USDC Join has 258185014360 USDC, pool has 22868196923 fyUSDC. Surplus is 235316 817437 USDC.
+
+At the time of submitting this proposal, the DAI March pool has a ratio of 100/139, and the USDC March pool has a ratio of 100/124. These ratios are being set on initialization for the June series.
+
+```
+/// Account used to deploy permissioned contracts
+export const deployer = '0xC7aE076086623ecEA2450e364C838916a043F9a8'
+
+// Amounts to initialize pools with, a pool being identified by the related seriesId
+// seriesId, initAmount
+export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
+  [FYDAI2206,  DAI, WAD.mul(100),  WAD.mul(39)], // The March series has a 100 / 139 ratio of base to fyToken. Virtual fyToken reserves will be 100 after init.
+  [FYUSDC2206, USDC, ONEUSDC.mul(100), ONEUSDC.mul(24)], // The March series has a 100 / 124 ratio of base to fyToken. Virtual fyToken reserves will be 100 after init.
+]
+
+// Ilks to accept for each series
+// seriesId, accepted ilks
+export const seriesIlks: Array<[string, string[]]> = [
+  [FYDAI2206,  [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI]],
+  [FYUSDC2206, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, YVUSDC]],
+]
+
+// Parameters to roll each strategy
+// strategyId, nextSeriesId, minRatio, maxRatio
+export const rollData: Array<[string, string, BigNumber, BigNumber]> = [
+  [YSDAI6MJD,  FYDAI2206,  BigNumber.from(0), MAX256],
+  [YSUSDC6MJD, FYUSDC2206, BigNumber.from(0), MAX256],
+]
+```
+
+The steps taken are four:
+1. Add new series
+2. Add ilks to new series
+3. Initialize pools
+4. Roll strategies
+
+```
+# Testing
+The change has been deployed on a mainnet fork in which the time has been advanced to the December 31st maturity date.
+```
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-3.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using fyToken at 0x2043452d7f1aaed1b5A266EFAa80e2D04872EB88 for 0x303130360000
+Using pool at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B for 0x303130360000
+Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
+Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303100000000
+Adding 0x303130360000 for 0x303100000000 using 0x2043452d7f1aaed1b5A266EFAa80e2D04872EB88
+Adding 0x303130360000 pool to Ladle using 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0106)): 0x3626908f13832885685558d66f4ca8bd8f19fdde961d2ff2426e340e7f6e37ed
+cloak.plan(fyToken, join(01)): 0x8d9a5d134eef7b3eb68d88b86f97dd46c652b029445c66279f45c22b8325b7e5
+Using fyToken at 0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C for 0x303230360000
+Using pool at 0xEf82611C6120185D3BF6e020D1993B49471E7da0 for 0x303230360000
+Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
+Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303200000000
+Adding 0x303230360000 for 0x303200000000 using 0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C
+Adding 0x303230360000 pool to Ladle using 0xEf82611C6120185D3BF6e020D1993B49471E7da0
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0206)): 0xf918d61c827768261fce8a8536c8e254ca106739d8f2977999d9e9a2b94df6f1
+cloak.plan(fyToken, join(02)): 0x198c4c9bffee98afd617b743ee4608a8f2e1880df1da469d9d2eef3218c24035
+addIlks 0106: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
+addIlks 0206: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
+Using pool at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B for 0x303130360000
+Initializing FYDAI2206LP at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B
+Initialized FYDAI2206LP with 100000000000000000000 base and 39000000000000000000 fyToken
+Using pool at 0xEf82611C6120185D3BF6e020D1993B49471E7da0 for 0x303230360000
+Initializing FYUSDC2206LP at 0xEf82611C6120185D3BF6e020D1993B49471E7da0
+Initialized FYUSDC2206LP with 100000000 base and 24000000 fyToken
+Using strategy at 0x1144e14E9B0AA9e181342c7e6E0a9BaDB4ceD295 for YSDAI6MJD
+Using pool at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B for 0x303130360000
+Strategy YSDAI6MJD divested from 0x303130340000
+Strategy YSDAI6MJD rolled onto 0x303130360000
+Using strategy at 0x8e8D6aB093905C400D583EfD37fbeEB1ee1c0c39 for YSUSDC6MJD
+Using pool at 0xEf82611C6120185D3BF6e020D1993B49471E7da0 for 0x303230360000
+Strategy YSUSDC6MJD divested from 0x303230340000
+Strategy YSUSDC6MJD rolled onto 0x303230360000
+Proposal: 0x1746c28b6cfffdba7f070aee2e7b8a555e7c8aac3cd63269e920a326e262ab92
+Executed 0x1746c28b6cfffdba7f070aee2e7b8a555e7c8aac3cd63269e920a326e262ab92
+```
+
+The g1 and g2 values being set are as follows:
+```
+g1 set to 13835058055282163712
+g2 set to 24595658764946068821
+```
+
+The ts value being set are as follows:
+```
+ts set to 23381681843
+```
+
+To convert the values from 64.64 to decimal, the [ABDK converter](https://toolkit.abdk.consulting/math#convert-number) can be used.


### PR DESCRIPTION
# Proposal
Initialize the fyToken and pool June contracts for the DAI and USDC June series.
Rollover the *JD strategies to the June pool contracts.

# Background
On December 31st 2021 the FYDAI2112 and FYUSDC2112 series will mature, and the YSDAI6MJD and YSUSDC6MJD strategies will stop accruing fees. At that date, we will activate the June series for DAI and USDC, and roll the YSDAI6MJD and YSUSDC6MJD strategies to the June pool contracts to provide them with liquidity.

# Details

The [activateJuneSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/activateJuneSeries.mainnet.sh) script  will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/3a4d77654ce5c5474b8b2a24693c7b68597f7a19/scripts/governance/addSeries/addJuneSeries/addJuneSeries.mainnet.config.ts):

At the time of submitting this proposal, both the DAI and USDC Joins have enough funds to serve the redemption of all the fyToken in de December series:
 - Dai Join has 609886630292632589467107 DAI, pool has 6788019263610582280742 fyDAI. Surplus is 603098 611029022007186365 DAI
 - USDC Join has 258185014360 USDC, pool has 22868196923 fyUSDC. Surplus is 235316 817437 USDC.

At the time of submitting this proposal, the DAI March pool has a ratio of 100/139, and the USDC March pool has a ratio of 100/124. These ratios are being set on initialization for the June series.

```
/// Account used to deploy permissioned contracts
export const deployer = '0xC7aE076086623ecEA2450e364C838916a043F9a8'

// Amounts to initialize pools with, a pool being identified by the related seriesId
// seriesId, initAmount
export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
  [FYDAI2206,  DAI, WAD.mul(100),  WAD.mul(39)], // The March series has a 100 / 139 ratio of base to fyToken. Virtual fyToken reserves will be 100 after init.
  [FYUSDC2206, USDC, ONEUSDC.mul(100), ONEUSDC.mul(24)], // The March series has a 100 / 124 ratio of base to fyToken. Virtual fyToken reserves will be 100 after init.
]

// Ilks to accept for each series
// seriesId, accepted ilks
export const seriesIlks: Array<[string, string[]]> = [
  [FYDAI2206,  [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI]],
  [FYUSDC2206, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, YVUSDC]],
]

// Parameters to roll each strategy
// strategyId, nextSeriesId, minRatio, maxRatio
export const rollData: Array<[string, string, BigNumber, BigNumber]> = [
  [YSDAI6MJD,  FYDAI2206,  BigNumber.from(0), MAX256],
  [YSUSDC6MJD, FYUSDC2206, BigNumber.from(0), MAX256],
]
```

The steps taken are four:
1. Add new series
2. Add ilks to new series
3. Initialize pools
4. Roll strategies

# Testing
The change has been deployed on a mainnet fork in which the time has been advanced to the December 31st maturity date.
```
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addJuneSeries/addJuneSeries-3.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using fyToken at 0x2043452d7f1aaed1b5A266EFAa80e2D04872EB88 for 0x303130360000
Using pool at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B for 0x303130360000
Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303100000000
Adding 0x303130360000 for 0x303100000000 using 0x2043452d7f1aaed1b5A266EFAa80e2D04872EB88
Adding 0x303130360000 pool to Ladle using 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0106)): 0x3626908f13832885685558d66f4ca8bd8f19fdde961d2ff2426e340e7f6e37ed
cloak.plan(fyToken, join(01)): 0x8d9a5d134eef7b3eb68d88b86f97dd46c652b029445c66279f45c22b8325b7e5
Using fyToken at 0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C for 0x303230360000
Using pool at 0xEf82611C6120185D3BF6e020D1993B49471E7da0 for 0x303230360000
Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303200000000
Adding 0x303230360000 for 0x303200000000 using 0x4568bBcf929AB6B4d716F2a3D5A967a1908B4F1C
Adding 0x303230360000 pool to Ladle using 0xEf82611C6120185D3BF6e020D1993B49471E7da0
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0206)): 0xf918d61c827768261fce8a8536c8e254ca106739d8f2977999d9e9a2b94df6f1
cloak.plan(fyToken, join(02)): 0x198c4c9bffee98afd617b743ee4608a8f2e1880df1da469d9d2eef3218c24035
addIlks 0106: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
addIlks 0206: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
Using pool at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B for 0x303130360000
Initializing FYDAI2206LP at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B
Initialized FYDAI2206LP with 100000000000000000000 base and 39000000000000000000 fyToken
Using pool at 0xEf82611C6120185D3BF6e020D1993B49471E7da0 for 0x303230360000
Initializing FYUSDC2206LP at 0xEf82611C6120185D3BF6e020D1993B49471E7da0
Initialized FYUSDC2206LP with 100000000 base and 24000000 fyToken
Using strategy at 0x1144e14E9B0AA9e181342c7e6E0a9BaDB4ceD295 for YSDAI6MJD
Using pool at 0x5D14Ab14adB3a3D9769a67a1D09634634bdE4C9B for 0x303130360000
Strategy YSDAI6MJD divested from 0x303130340000
Strategy YSDAI6MJD rolled onto 0x303130360000
Using strategy at 0x8e8D6aB093905C400D583EfD37fbeEB1ee1c0c39 for YSUSDC6MJD
Using pool at 0xEf82611C6120185D3BF6e020D1993B49471E7da0 for 0x303230360000
Strategy YSUSDC6MJD divested from 0x303230340000
Strategy YSUSDC6MJD rolled onto 0x303230360000
Proposal: 0x1746c28b6cfffdba7f070aee2e7b8a555e7c8aac3cd63269e920a326e262ab92
Executed 0x1746c28b6cfffdba7f070aee2e7b8a555e7c8aac3cd63269e920a326e262ab92
```