### PR TITLE
Update auction settings

### DIFF
--- a/YPP-0027.md
+++ b/YPP-0027.md
@@ -1,0 +1,63 @@
+# Proposal
+Set the initial offer for DAI to 75.1%, and the auction limits to their correct values for all collaterals.
+
+# Background
+The auction limits for maximum collateral that can be auctioned at once, and minimum debt that can be left in a partial liquidation, were set incorrectly. The present values were copied from the Cauldron limits and make no sense. Fortunately, there is no risk as there are no vaults to liquidate with the affected collaterals, and partial liquidations are not essential yet for the protocol.
+
+# Details
+The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/updateAuctions/updateAuctions.ts) script will be used, with this input:
+```
+// Input data: ilkId, auctionLine, auctionDust, dec
+export const newLimits: Array<[string, number, number, number]> = [
+  [ETH,    500000000, 10000, 12],
+  [DAI,    1000000,   5000,  18],
+  [USDC,   1000000,   5000,  6],
+  [WBTC,   300000,    2100,  4],
+  [WSTETH, 500000,    10000, 12],
+  [LINK,   1000000,   300,   18],
+  [ENS,    2000000,   300,   18],
+  [YVUSDC, 1000000,   5000,  18],
+  [UNI,    1000000,   100,   18],
+]
+
+
+// Input data: ilkId, initialOffer
+export const newInitialOffer: Array<[string, number]> = [
+  [ETH,    714000],
+  [DAI,    751000],
+  [USDC,   751000],
+  [WBTC,   666000],
+  [WSTETH, 714000],
+  [LINK,   600000],
+  [ENS,    600000],
+  [YVUSDC, 800000],
+  [UNI,    600000],
+]
+```
+# Testing
+The change has been tested on a mainnet fork by running [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/updateAuctions/updateAuctions.ts) first followed by [updateAuctions.test.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/updateAuctions/updateAuctions.test.ts) to verify that the changes were made.
+```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost scripts/governance/updateAuctions/updateAuctions.ts
+No need to generate any newer typings.
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+00: 100000/1/18 -> 500000000/10000/12
+01: 10000000/0/18 -> 1000000/5000/18
+02: 100000/1/18 -> 1000000/5000/6
+03: 100000/1/18 -> 300000/2100/4
+04: 500000/1/18 -> 500000/10000/12
+06: 1000000/100/18 -> 1000000/300/18
+07: 500000/100/18 -> 2000000/300/18
+09: 1000000/5000/6 -> 1000000/5000/18
+10: 1000000/5000/18 -> 1000000/100/18
+00: 714000 -> 714000
+01: 1000000 -> 751000
+02: 751000 -> 751000
+03: 666000 -> 666000
+04: 714000 -> 714000
+06: 600000 -> 600000
+07: 600000 -> 600000
+09: 800000 -> 800000
+10: 600000 -> 600000
+Proposal: 0xb95fef06f824cd7cbb2e9139468416b8f914fea4c1d8afe3d35f890cc3f5f4d6
+Executed 0xb95fef06f824cd7cbb2e9139468416b8f914fea4c1d8afe3d35f890cc3f5f4d6
+```


### PR DESCRIPTION
# Proposal
Set the initial offer for DAI to 75.1%.
Set the concurrent auction limits to about $10M for all collaterals.
Set the minimum vault collateral during auction to about $5K for all collaterals.

# Background
The auction limits for maximum collateral that can be auctioned at once, and minimum debt that can be left in a partial liquidation, were set incorrectly. The present values were copied from the Cauldron limits and make no sense. Fortunately, there is no risk as there are no vaults to liquidate with the affected collaterals, and partial liquidations are not essential yet for the protocol.

# Details
The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/updateAuctions/updateAuctions.ts) script will be used, with this input:
```
// Input data: ilkId, initialOffer, auctionLine, auctionDust, dec
export const newLimits: Array<[string, number, number, number, number]> = [
  [ETH,    714000, 3250000000, 1500000, 12],
  [DAI,    751000, 10000000,   5000,    18],
  [USDC,   751000, 10000000,   5000,    6],
  [WBTC,   666000, 2500000,    1200,    4],
  [WSTETH, 714000, 3250000000, 1500000, 12],
  [LINK,   600000, 600000,     300,     18],
  [ENS,    600000, 500000,     250,     18],
  [YVUSDC, 800000, 10000000,   5000,    6],
  [UNI,    600000, 1000000,    400,     18],
]
```

[This spreadsheet](https://docs.google.com/spreadsheets/d/154fbcsINi2fs1E9rK8qnDtLlJzwaK53PbqPXLWAomfU) can be used to translate the parameters above to USD.

![image](https://user-images.githubusercontent.com/38806121/152972175-70c01c4e-c702-4bc1-9695-d8ea3520b89a.png)

# Testing
The change has been tested on a mainnet fork by running [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/updateAuctions/updateAuctions.ts) first followed by [updateAuctions.test.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/updateAuctions/updateAuctions.test.ts) to verify that the changes were made.
```
 ~/Documents/Crypto/Yield/environments-v2   feat/update-auctions ⍟4  npx hardhat run --network localhost scripts/governance/updateAuctions/updateAuctions.test.ts                                                                 
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Limits:
00 line set: 3250000000
00 dust set: 1500000
00 dec set: 12
00 initialOffer set: 714000
01 line set: 10000000
01 dust set: 5000
01 dec set: 18
01 initialOffer set: 751000
02 line set: 10000000
02 dust set: 5000
02 dec set: 6
02 initialOffer set: 751000
03 line set: 2500000
03 dust set: 1200
03 dec set: 4
03 initialOffer set: 666000
04 line set: 3250000000
04 dust set: 1500000
04 dec set: 12
04 initialOffer set: 714000
06 line set: 600000
06 dust set: 300
06 dec set: 18
06 initialOffer set: 600000
07 line set: 500000
07 dust set: 250
07 dec set: 18
07 initialOffer set: 600000
09 line set: 10000000
09 dust set: 5000
09 dec set: 6
09 initialOffer set: 800000
10 line set: 1000000
10 dust set: 400
10 dec set: 18
10 initialOffer set: 600000
 ~/Documents/Crypto/Yield/environments-v2  feat/update-auctions ⍟4     
```