### PR TITLE
Update timelock delay

### DIFF
--- a/YPP-0028.md
+++ b/YPP-0028.md
@@ -1,0 +1,37 @@
+# Proposal
+Set the delay of the timelock to 2 days
+
+# Background
+Currently the delay of timelock is set to 0. This means proposal could be approved and executed in subsequent transactions. The ability of proposal getting executed with no time for the community to get to a decision is not favourable for the long term of the protocol & might lead to the community loosing trust.
+
+# Details
+The [updateTimelockDelay.ts](https://github.com/yieldprotocol/environments-v2/blob/1353d5c6c14ec313cb933d07c4678d1cd867c630/scripts/governance/updateTimelockDelay/updateTimelockDelay.ts) script will be used with a time delay of 2 days.
+
+# Testing
+The change has been tested on a mainnet fork by running [updateTimelockDelay.ts](https://github.com/yieldprotocol/environments-v2/blob/1353d5c6c14ec313cb933d07c4678d1cd867c630/scripts/governance/updateTimelockDelay/updateTimelockDelay.ts) first followed by [updateTimelockDelay.test.ts](https://github.com/yieldprotocol/environments-v2/blob/1353d5c6c14ec313cb933d07c4678d1cd867c630/scripts/governance/updateTimelockDelay/updateTimelockDelay.test.ts) to verify that the changes were made.
+```
+ ~/Documents/Crypto/Yield/environments-v2   feat/update-timelock-delay ⍟4  npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.ts
+No need to generate any newer typings.
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+setDelay to 172800
+Proposal: 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
+Proposed 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
+ ~/Documents/Crypto/Yield/environments-v2   feat/update-timelock-delay ⍟4  npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.ts
+No need to generate any newer typings.
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+setDelay to 172800
+Proposal: 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
+Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
+Approved 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
+ ~/Documents/Crypto/Yield/environments-v2   feat/update-timelock-delay ⍟4  npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.ts
+No need to generate any newer typings.
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+setDelay to 172800
+Proposal: 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
+Executed 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
+ ~/Documents/Crypto/Yield/environments-v2   feat/update-timelock-delay ⍟4  npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.test.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+New delay set to 172800
+```


### PR DESCRIPTION
# Proposal
Set the delay of the timelock to 2 days

# Background
Currently the delay of timelock is set to 0. This means proposal could be approved and executed in subsequent transactions. The ability of proposal getting executed with no time for the community to get to a decision is not favourable for the long term of the protocol & might lead to the community loosing trust.

# Details
The [updateTimelockDelay.ts](https://github.com/yieldprotocol/environments-v2/blob/1353d5c6c14ec313cb933d07c4678d1cd867c630/scripts/governance/updateTimelockDelay/updateTimelockDelay.ts) script will be used with a time delay of 2 days.

# Testing
The change has been tested on a mainnet fork by running [updateTimelockDelay.ts](https://github.com/yieldprotocol/environments-v2/blob/1353d5c6c14ec313cb933d07c4678d1cd867c630/scripts/governance/updateTimelockDelay/updateTimelockDelay.ts) first followed by [updateTimelockDelay.test.ts](https://github.com/yieldprotocol/environments-v2/blob/1353d5c6c14ec313cb933d07c4678d1cd867c630/scripts/governance/updateTimelockDelay/updateTimelockDelay.test.ts) to verify that the changes were made.
```
 ~/Documents/Crypto/Yield/environments-v2> npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.ts
No need to generate any newer typings.
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
setDelay to 172800
Proposal: 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
Proposed 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
 ~/Documents/Crypto/Yield/environments-v2> npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.ts
No need to generate any newer typings.
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
setDelay to 172800
Proposal: 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
Approved 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
 ~/Documents/Crypto/Yield/environments-v2> npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.ts
No need to generate any newer typings.
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
setDelay to 172800
Proposal: 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
Executed 0xb5f9adab861e60957d7e49f69f3aae27360249b49963ba9f3e86ddaf759d5996
 ~/Documents/Crypto/Yield/environments-v2> npx hardhat run --network localhost scripts/governance/updateTimelockDelay/updateTimelockDelay.test.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
New delay set to 172800
```