### PR TITLE
fCash as collateral

### DIFF
--- a/YPP-0029.md
+++ b/YPP-0029.md
@@ -29,9 +29,7 @@ export const fCashAddress = '0x1344A36A1B56144C3Bc62E7757377D288fDE0369'
 /// @param underlying: contract address matching underlyingId
 export const notionalSources: Array<[string, string, string, string]> = [
   [fCashAddress, FDAI2203, DAI, assets.get(DAI) as string],
-  [fCashAddress, FDAI2206, DAI, assets.get(DAI) as string],
   [fCashAddress, FUSDC2203, USDC, assets.get(USDC) as string],
-  [fCashAddress, FUSDC2206, USDC, assets.get(USDC) as string],
 ]
 
 /// @dev Assets for which we will deploy a Join
@@ -40,9 +38,7 @@ export const notionalSources: Array<[string, string, string, string]> = [
 /// @param fcash: address of the fCash contract
 export const assetsToAdd: Array<[string, number, string]> = [
   [FDAI2203, FDAI2203ID, fCashAddress],
-  [FDAI2206, FDAI2206ID, fCashAddress],
   [FUSDC2203, FUSDC2203ID, fCashAddress],
-  [FUSDC2206, FUSDC2206ID, fCashAddress],
 ]
 
 /// @dev Collateralization ratio, debt ceiling, and debt dust
@@ -54,9 +50,7 @@ export const assetsToAdd: Array<[string, number, string]> = [
 /// @param dec: number of zeros to append to line and dust
 export const notionalDebtLimits: Array<[string, string, number, number, number, number]> = [
   [DAI, FDAI2203, 1100000, 1000000, 5000, 18],
-  [DAI, FDAI2206, 1100000, 1000000, 5000, 18],
   [USDC, FUSDC2203, 1100000, 1000000, 5000, 6],
-  [USDC, FUSDC2206, 1100000, 1000000, 5000, 6],
 ]
 
 /// @dev Parameters for liquidations
@@ -74,9 +68,7 @@ export const auctionLimits: Array<[string, number, number, number, number, numbe
 /// @param [ilkIds]: array of asset ids to be newly accepted as collateral
 export const seriesIlks: Array<[string, string[]]> = [
   [FYDAI2203, [FDAI2203]],
-  [FYDAI2206, [FDAI2206]],
   [FYUSDC2203, [FUSDC2203]],
-  [FYUSDC2206, [FUSDC2206]],
 ]
 ```
 

--- a/YPP-0029.md
+++ b/YPP-0029.md
@@ -49,8 +49,8 @@ export const assetsToAdd: Array<[string, number, string]> = [
 /// @param dust: minimum debt in any given vault for the pair, with added dec
 /// @param dec: number of zeros to append to line and dust
 export const notionalDebtLimits: Array<[string, string, number, number, number, number]> = [
-  [DAI, FDAI2203, 1100000, 1000000, 5000, 18],
-  [USDC, FUSDC2203, 1100000, 1000000, 5000, 6],
+  [DAI, FDAI2203, 1100000, 100000, 5000, 18],
+  [USDC, FUSDC2203, 1100000, 100000, 5000, 6],
 ]
 
 /// @dev Parameters for liquidations

--- a/YPP-0029.md
+++ b/YPP-0029.md
@@ -81,4 +81,18 @@ export const seriesIlks: Array<[string, string[]]> = [
 ```
 
 # Testing
-TBA
+Posting, borrowing, repaying and withdrawing has been tested on a mainnet fork:
+```
+alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost ./scripts/governance/addFCashCollateral/addFCash.test.ts 
+No need to generate any newer typings.
+758696853424417 FCASH563373963149313 available
+series: 0x303130360000
+vault: 0xda3f2af6e2bacdf42d8902b2
+posted and borrowed
+repaid and withdrawn
+713541975762446 FCASH844848939859969 available
+series: 0x303230360000
+vault: 0x9331f672b34300531614227a
+posted and borrowed
+repaid and withdrawn
+```

--- a/YPP-0029.md
+++ b/YPP-0029.md
@@ -1,0 +1,84 @@
+# Proposal
+Enable Notional fCash as a collateral for DAI and USDC loans.
+
+# Background
+Notional Finance allows fixed rate borrowing and lending, as does the Yield Protocol. There is an opportunity for arbitrage and leverage by integrating both platforms. As of now, lending rates exceed 5% in DAI and USDC for maturities that overlap those in the Yield Protocol. Borrowing rates in the Yield Protocol have often been well below 5%.
+
+
+# Details
+To enable fCash as a collateral we will be using a new ERC1155 compatible Join contract, a minimal module on the Ladle to transfer ERC1155 tokens, and an oracle that prices fCash at face value. Details on this integration can be found on the [vault](https://github.com/yieldprotocol/vault-v2/blob/master/contracts/other/notional/README.md) repo.
+
+The fCash maturities that will be accepted as collateral will be those for which a similar Yield series exists. FCash will be accepted as collateral to borrow only its underlying, with a collateralization ratio of 110%.
+
+Steps:
+1. [FCash Oracle deployment](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-1.ts)
+2. [ERC1155 Ladle module](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-2.ts)
+3. [ERC1155 Join deployments](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-3.ts)
+4. [FCash as collateral](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-4.ts)
+
+```
+export const fCashAddress = '0x1344A36A1B56144C3Bc62E7757377D288fDE0369'
+
+/// @dev The Notional Oracle is fed with Yield Protocol asset pairs to register.
+/// Since we are valuing the fCash at face value, we don't need the Notional fCash ids. 
+/// Note: notionalId (FDAI2203) is the id of an fCash tenor in the Yield Protocol,
+/// while fCashId (FDAI2203ID) is the id of that same tenor in Notional Finance
+/// @param fcash: address of the fCash contract
+/// @param notionalId: asset id of an fCash tenor in the Yield Protocol
+/// @param underlyingId: asset id of a borrowable asset in the Yield Protocol
+/// @param underlying: contract address matching underlyingId
+export const notionalSources: Array<[string, string, string, string]> = [
+  [fCashAddress, FDAI2203, DAI, assets.get(DAI) as string],
+  [fCashAddress, FDAI2206, DAI, assets.get(DAI) as string],
+  [fCashAddress, FUSDC2203, USDC, assets.get(USDC) as string],
+  [fCashAddress, FUSDC2206, USDC, assets.get(USDC) as string],
+]
+
+/// @dev Assets for which we will deploy a Join
+/// @param notionalId: asset id of an fCash tenor in the Yield Protocol
+/// @param fCashId: id of that same tenor in Notional Finance
+/// @param fcash: address of the fCash contract
+export const assetsToAdd: Array<[string, number, string]> = [
+  [FDAI2203, FDAI2203ID, fCashAddress],
+  [FDAI2206, FDAI2206ID, fCashAddress],
+  [FUSDC2203, FUSDC2203ID, fCashAddress],
+  [FUSDC2206, FUSDC2206ID, fCashAddress],
+]
+
+/// @dev Collateralization ratio, debt ceiling, and debt dust
+/// @param baseId: asset id of a borrowable asset
+/// @param ilkId: asset id of a collateral asset
+/// @param ratio: collateralization ratio for the base/ilk pair, with 1000000 == 100%
+/// @param line: maximum debt across the protocol for the pair, with added dec
+/// @param dust: minimum debt in any given vault for the pair, with added dec
+/// @param dec: number of zeros to append to line and dust
+export const notionalDebtLimits: Array<[string, string, number, number, number, number]> = [
+  [DAI, FDAI2203, 1100000, 1000000, 5000, 18],
+  [DAI, FDAI2206, 1100000, 1000000, 5000, 18],
+  [USDC, FUSDC2203, 1100000, 1000000, 5000, 6],
+  [USDC, FUSDC2206, 1100000, 1000000, 5000, 6],
+]
+
+/// @dev Parameters for liquidations
+/// Note: fCash-collateralized positions can't get liquidated
+/// @param ilkId: asset id of a collateral asset
+/// @param duration: time for an auction to reach the minimum price
+/// @param initialOffer: proportion of collateral to be offered at the start of an auction
+/// @param auctionLine: maximum collateral of ilkId that can be simultaneously auctioned
+/// @param auctionDust: minimum collateral of ilkId that can be left in a non-empty vault
+/// @param ilkDec: number of zeros to append to auctionLine and auctionDust
+export const auctionLimits: Array<[string, number, number, number, number, number]> = []
+
+/// @dev Newly accepted collaterals
+/// @param seriesId: series in the yield Protocol
+/// @param [ilkIds]: array of asset ids to be newly accepted as collateral
+export const seriesIlks: Array<[string, string[]]> = [
+  [FYDAI2203, [FDAI2203]],
+  [FYDAI2206, [FDAI2206]],
+  [FYUSDC2203, [FUSDC2203]],
+  [FYUSDC2206, [FUSDC2206]],
+]
+```
+
+# Testing
+TBA


### PR DESCRIPTION
# Proposal
Enable Notional fCash as a collateral for DAI and USDC loans.

# Background
Notional Finance allows fixed rate borrowing and lending, as does the Yield Protocol. There is an opportunity for arbitrage and leverage by integrating both platforms. As of now, lending rates exceed 5% in DAI and USDC for maturities that overlap those in the Yield Protocol. Borrowing rates in the Yield Protocol have often been well below 5%.

# Details
To enable fCash as a collateral we will be using a new ERC1155 compatible Join contract, a minimal module on the Ladle to transfer ERC1155 tokens, and an oracle that prices fCash at face value. Details on this integration can be found on the [vault](https://github.com/yieldprotocol/vault-v2/blob/master/contracts/other/notional/README.md) repo.

The fCash maturities that will be accepted as collateral will be those for which a similar Yield series exists. FCash will be accepted as collateral to borrow only its underlying, with a collateralization ratio of 110%.

In this release, we will target the March maturities with a debt ceiling of $100K USD. The feature will be live for about a week, after which we should enable longer-dated maturities with a higher debt ceiling.

Steps:
1. [FCash Oracle deployment](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-1.ts)
2. [ERC1155 Ladle module](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-2.ts)
3. [ERC1155 Join deployments](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-3.ts)
4. [FCash as collateral](https://github.com/yieldprotocol/environments-v2/blob/7a35d72a64007a89b688d2e4d430744f9a58065b/scripts/governance/addFCashCollateral/addFCash-4.ts)

```
import { USDC, DAI } from '../../../shared/constants'
import { FUSDC2203, FDAI2203 } from '../../../shared/constants'
import { FCASH_MAR22, FCASH_DAI, FCASH_USDC } from '../../../shared/constants'
import { FYUSDC2203, FYDAI2203 } from '../../../shared/constants'

export const fCashAddress = '0x1344A36A1B56144C3Bc62E7757377D288fDE0369'

// fcash, notionalId, underlyingId, underlying
export const notionalSources: Array<[string, string, string, string]> = [
  [fCashAddress, FDAI2203, DAI, assets.get(DAI) as string],
  [fCashAddress, FUSDC2203, USDC, assets.get(USDC) as string],
]

// Assets for which we will have a Join
// assetId, fCashId, fCash
export const assetsToAdd: Array<[string, string, string, number, string]> = [
  [FDAI2203, fCashAddress, assets.get(DAI) as string, FCASH_MAR22, FCASH_DAI],
  [FUSDC2203, fCashAddress, assets.get(USDC) as string, FCASH_MAR22, FCASH_USDC],
]

// Input data: baseId, ilkId, ratio (1000000 == 100%), line, dust, dec
export const notionalDebtLimits: Array<[string, string, number, number, number, number]> = [
  [DAI, FDAI2203, 1100000, 100000, 5000, 18],
  [USDC, FUSDC2203, 1100000, 100000, 5000, 6],
]

// Input data: ilkId, duration, initialOffer, auctionLine, auctionDust, ilkDec
// Fcash cannot get liquidated
export const auctionLimits: Array<[string, number, number, number, number, number]> = []

// Input data: seriesId, [ilkIds]
export const seriesIlks: Array<[string, string[]]> = [
  [FYDAI2203, [FDAI2203]],
  [FYUSDC2203, [FUSDC2203]],
]
```

# Testing
Posting, borrowing, repaying and withdrawing has been tested on a mainnet fork:
```
alberto@alberto-laptop:~/Code/Yield/environments-v2$ npx hardhat run --network localhost ./scripts/governance/addFCashCollateral/addFCash.test.ts 
No need to generate any newer typings.
758696853424417 FCASH563373963149313 available
series: 0x303130360000
vault: 0xda3f2af6e2bacdf42d8902b2
posted and borrowed
repaid and withdrawn
713541975762446 FCASH844848939859969 available
series: 0x303230360000
vault: 0x9331f672b34300531614227a
posted and borrowed
repaid and withdrawn
```