### PR TITLE
Chainlink Oracle Replacement

### DIFF
--- a/YPP-0030.md
+++ b/YPP-0030.md
@@ -1,0 +1,57 @@
+# Proposal
+Replace the Chainlink Oracle in Arbitrum for an L2 specific one.
+
+# Background
+In Arbitrum, Chainlink [recommends to verify the availability of the sequencer](https://docs.chain.link/docs/l2-sequencer-flag/) before consuming their data feeds. By mistake we deployed the L1 USD Chainlink Oracle that doesn't do so.
+
+# Details
+1. Deploy new oracle.
+2. The orchestration and configuration of the new oracle mimics the environment deployment. A new step is included that replaces the spot oracle in the Cauldron for the newly deployed oracle, for the pairs specified.
+
+Deployment scripts can be found [here](https://github.com/yieldprotocol/environments-v2/tree/feat/replaceChainlinkL2Oracle/scripts/governance/replaceChainlinkL2USDOracle) for those with appropriate permissioning.
+
+Configuration:
+```
+export const sequencerFlags: string = '0x3C14e07Edd0dC67442FA96f1Ec6999c57E810a83'
+
+export const chainlinkUSDSources: Array<[string, string, string]> = [
+  [ETH, assets.get(ETH) as string, '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612'],
+  [DAI, assets.get(DAI) as string, '0xc5C8E77B397E531B8EC06BFb0048328B30E9eCfB'],
+  [USDC, assets.get(USDC) as string, '0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3'],
+]
+
+// Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), line, dust, dec
+export const assetPairs: Array<[string, string, string]> = [
+  [DAI, ETH, protocol.get(CHAINLINKUSD) as string],
+  [DAI, DAI, protocol.get(CHAINLINKUSD) as string],
+  [DAI, USDC, protocol.get(CHAINLINKUSD) as string],
+  [USDC, ETH, protocol.get(CHAINLINKUSD) as string],
+  [USDC, DAI, protocol.get(CHAINLINKUSD) as string],
+  [USDC, USDC, protocol.get(CHAINLINKUSD) as string],
+]
+```
+
+# Testing
+The change has been tested on a mainnet fork:
+```
++ npx hardhat run --network localhost ./scripts/governance/replaceChainlinkL2USDOracle/setupOracles.ts
+No need to generate any newer typings.
+chainlinkUSDOracle.grantRoles(gov, timelock)
+chainlinkUSDOracle.grantRole(ROOT, cloak)
+chainlinkUSDOracle.revokeRole(ROOT, deployer)
+Setting up 0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612 as the source for 0x303000000000/USD at 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Aggregator decimals: 8
+Setting up 0xc5C8E77B397E531B8EC06BFb0048328B30E9eCfB as the source for 0x303100000000/USD at 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Aggregator decimals: 8
+Setting up 0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3 as the source for 0x303200000000/USD at 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Aggregator decimals: 8
+Spot oracle for 0x303100000000/0x303000000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Spot oracle for 0x303100000000/0x303100000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Spot oracle for 0x303100000000/0x303200000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Spot oracle for 0x303200000000/0x303000000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Spot oracle for 0x303200000000/0x303100000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Spot oracle for 0x303200000000/0x303200000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
+Proposal: 0xde5f416d09cc8c6ccb4138eeeb9b6a05d992c4a16ad8f367b41c3479884ba918
+Executing
+Executed 0xde5f416d09cc8c6ccb4138eeeb9b6a05d992c4a16ad8f367b41c3479884ba918
+```


### PR DESCRIPTION
# Proposal
Replace the Chainlink Oracle in Arbitrum for an L2 specific one.

# Background
In Arbitrum, Chainlink [recommends to verify the availability of the sequencer](https://docs.chain.link/docs/l2-sequencer-flag/) before consuming their data feeds. By mistake we deployed the L1 USD Chainlink Oracle that doesn't do so.

# Details
1. Deploy new oracle.
2. The orchestration and configuration of the new oracle mimics the environment deployment. A new step is included that replaces the spot oracle in the Cauldron for the newly deployed oracle, for the pairs specified.

Deployment scripts can be found [here](https://github.com/yieldprotocol/environments-v2/tree/feat/replaceChainlinkL2Oracle/scripts/governance/replaceChainlinkL2USDOracle) for those with appropriate permissioning.

Configuration:
```
export const sequencerFlags: string = '0x3C14e07Edd0dC67442FA96f1Ec6999c57E810a83'

export const chainlinkUSDSources: Array<[string, string, string]> = [
  [ETH, assets.get(ETH) as string, '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612'],
  [DAI, assets.get(DAI) as string, '0xc5C8E77B397E531B8EC06BFb0048328B30E9eCfB'],
  [USDC, assets.get(USDC) as string, '0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3'],
]

// Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), line, dust, dec
export const assetPairs: Array<[string, string, string]> = [
  [DAI, ETH, protocol.get(CHAINLINKUSD) as string],
  [DAI, DAI, protocol.get(CHAINLINKUSD) as string],
  [DAI, USDC, protocol.get(CHAINLINKUSD) as string],
  [USDC, ETH, protocol.get(CHAINLINKUSD) as string],
  [USDC, DAI, protocol.get(CHAINLINKUSD) as string],
  [USDC, USDC, protocol.get(CHAINLINKUSD) as string],
]
```

# Testing
The change has been tested on a mainnet fork:
```
+ npx hardhat run --network localhost ./scripts/governance/replaceChainlinkL2USDOracle/setupOracles.ts
No need to generate any newer typings.
chainlinkUSDOracle.grantRoles(gov, timelock)
chainlinkUSDOracle.grantRole(ROOT, cloak)
chainlinkUSDOracle.revokeRole(ROOT, deployer)
Setting up 0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612 as the source for 0x303000000000/USD at 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Aggregator decimals: 8
Setting up 0xc5C8E77B397E531B8EC06BFb0048328B30E9eCfB as the source for 0x303100000000/USD at 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Aggregator decimals: 8
Setting up 0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3 as the source for 0x303200000000/USD at 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Aggregator decimals: 8
Spot oracle for 0x303100000000/0x303000000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Spot oracle for 0x303100000000/0x303100000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Spot oracle for 0x303100000000/0x303200000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Spot oracle for 0x303200000000/0x303000000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Spot oracle for 0x303200000000/0x303100000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Spot oracle for 0x303200000000/0x303200000000 set to 0x8E9696345632796e7D80fB341fF4a2A60aa39C89
Proposal: 0xde5f416d09cc8c6ccb4138eeeb9b6a05d992c4a16ad8f367b41c3479884ba918
Executing
Executed 0xde5f416d09cc8c6ccb4138eeeb9b6a05d992c4a16ad8f367b41c3479884ba918
```
