### PR TITLE
September 2022 Series

### DIFF
--- a/YPP-0031.md
+++ b/YPP-0031.md
@@ -1,0 +1,297 @@
+# Proposal
+Deploy the fyToken and pool contracts for the DAI and USDC September series
+
+# Background
+On March 25th 2022 the FYDAI2203 and FYUSDC2203 series will mature, and the YSDAI6MMS and YSUSDC6MMS strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled.
+
+# Details
+Here are the steps:
+1. Deploy fyToken contracts for FYDAI2209 & FYUSDC2209 (no need for governance approval)
+2. Deploy pool contracts(no need for governance approval)
+3. Governance proposal
+    1. Add new series
+    2. Add ilks to the new series
+    3. Initialize new pools
+    4. Roll the strategies to the next pool
+
+We would be deploying the fyTokens & pools using the [deploySeptSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/deploySeptSeries.mainnet.sh), with [this input](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config.ts):
+
+```
+// Parameters to deploy fyToken with
+// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
+export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
+  [FYDAI2209, DAI, protocol.get(COMPOUND) as string, joins.get(DAI) as string, EOSEPT22, 'FYDAI2209', 'FYDAI2209'],
+  [FYUSDC2209, USDC, protocol.get(COMPOUND) as string, joins.get(USDC) as string, EOSEPT22, 'FYUSDC2209', 'FYUSDC2209'],
+]
+
+// Parameters to deploy pools with, a pool being identified by the related seriesId
+// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee), g2 (Sell fyToken to the pool fee)
+export const poolData: Array<[string, string, string, BigNumber, BigNumber, BigNumber]> = [
+  [
+    FYDAI2209,
+    assets.get(DAI) as string,
+    fyTokens.get(FYDAI2209) as string,
+    ONE64.div(secondsIn30Years),
+    ONE64.mul(75).div(100),
+    ONE64.mul(100).div(75),
+  ],
+  [
+    FYUSDC2209,
+    assets.get(USDC) as string,
+    fyTokens.get(FYUSDC2209) as string,
+    ONE64.div(secondsIn30Years),
+    ONE64.mul(75).div(100),
+    ONE64.mul(100).div(75),
+  ],
+]
+```
+We would be activating the series using [activateSeptSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/activateSeptSeries.mainnet.sh) with [this input](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config.ts)
+
+```
+// Amounts to initialize pools with, a pool being identified by the related seriesId
+// seriesId, baseId, baseAmount, fyTokenAmount
+export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
+  [FYDAI2209, DAI, WAD.mul(100), WAD.mul(6)],
+  [FYUSDC2209, USDC, ONEUSDC.mul(100), ONEUSDC.mul(4)],
+]
+
+// Ilks to accept for each series
+// seriesId, accepted ilks
+export const seriesIlks: Array<[string, string[]]> = [
+  [FYDAI2209, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI]],
+  [FYUSDC2209, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, YVUSDC]],
+]
+
+// Parameters to roll each strategy
+// strategyId, nextSeriesId, minRatio, maxRatio
+export const rollData: Array<[string, string, BigNumber, BigNumber]> = [
+  [YSDAI6MMS, FYDAI2209, BigNumber.from(0), MAX256],
+  [YSUSDC6MMS, FYUSDC2209, BigNumber.from(0), MAX256],
+]
+```
+
+# Testing
+The change has been deployed on a mainnet fork with the following output.
+```
+~/Documents/Crypto/Yield/environments-v2   feat/roll-marchtosept-2022 ● ⍟4  ./scripts/governance/addSeries/addSeptSeries/deploySeptSeries.mainnet.sh
+++ dirname ./scripts/governance/addSeries/addSeptSeries/deploySeptSeries.mainnet.sh
++ HERE=./scripts/governance/addSeries/addSeptSeries
++ export CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config
++ CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config
++ RUN='npx hardhat run --network localhost'
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/../../newEnvironment/deployFYTokens.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303130390000
+Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303130390000
+FYToken deployed at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
+npx hardhat verify --network localhost 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE 0x303100000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc 1664550000 FYDAI2209 FYDAI2209 --libraries safeERC20Namer.js
+fyToken.grantRoles(ROOT, timelock)
+Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303230390000
+Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303230390000
+FYToken deployed at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
+npx hardhat verify --network localhost 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc 0x303200000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 1664550000 FYUSDC2209 FYUSDC2209 --libraries safeERC20Namer.js
+fyToken.grantRoles(ROOT, timelock)
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/../../newEnvironment/deployPools.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using base at 0x6B175474E89094C44Da98b954EedeAC495271d0F
+Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
+Pool deployed at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+npx hardhat verify --network localhost 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c 0x6B175474E89094C44Da98b954EedeAC495271d0F 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE 19484734869 13835058055282163712 24595658764946068821 --libraries yieldMath.js
+Using base at 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
+Pool deployed at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+npx hardhat verify --network localhost 0xefc1aB2475ACb7E60499Efb171D173be19928a05 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc 19484734869 13835058055282163712 24595658764946068821 --libraries yieldMath.js
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries-3.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE for 0x303130390000
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
+Adding 0x303130390000 for 0x303100000000 using 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
+Adding 0x303130390000 pool to Ladle using 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0109)): 0x8af89d8f65ca9a27a2416d98942394bc6f89c6ee1d19ecda5185d9acc8c2f135
+cloak.plan(fyToken, join(01)): 0x80d6bb80bff661aae56e873f9bdcbf04977f2ffb2487abad722f36bb1a397265
+Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc for 0x303230390000
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
+Adding 0x303230390000 for 0x303200000000 using 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
+Adding 0x303230390000 pool to Ladle using 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0209)): 0x41a1a7b3b8fe5596d9aa75d9c67042bfb299aa14473c4893b154145515101393
+cloak.plan(fyToken, join(02)): 0x1334c6e7bfdb432416afae20605e2b45db7001b1543a24fa25d9998073e8828d
+Updating 0x303130390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000 ilks
+addIlks 0109: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
+Updating 0x303230390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000 ilks
+addIlks 0209: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Timelock balance of 0x303100000000 is 145999585760000000000
+Transferring 100000000000000000000 of 0x303100000000 from Timelock to Pool
+Initializing FYDAI2209LP at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+Transferring 6000000000000000000 of 0x303100000000 from Timelock to Join
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Timelock balance of 0x303200000000 is 104000000
+Transferring 100000000 of 0x303200000000 from Timelock to Pool
+Initializing FYUSDC2209LP at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+Transferring 4000000 of 0x303200000000 from Timelock to Join
+Using strategy at 0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD for YSDAI6MMS
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Strategy YSDAI6MMS divested from 0x303130350000
+Strategy YSDAI6MMS rolled onto 0x303130390000
+Using strategy at 0xFBc322415CBC532b54749E31979a803009516b5D for YSUSDC6MMS
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Strategy YSUSDC6MMS divested from 0x303230350000
+Strategy YSUSDC6MMS rolled onto 0x303230390000
+Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
+Proposing
+Proposed 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries-3.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE for 0x303130390000
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
+Adding 0x303130390000 for 0x303100000000 using 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
+Adding 0x303130390000 pool to Ladle using 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0109)): 0x8af89d8f65ca9a27a2416d98942394bc6f89c6ee1d19ecda5185d9acc8c2f135
+cloak.plan(fyToken, join(01)): 0x80d6bb80bff661aae56e873f9bdcbf04977f2ffb2487abad722f36bb1a397265
+Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc for 0x303230390000
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
+Adding 0x303230390000 for 0x303200000000 using 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
+Adding 0x303230390000 pool to Ladle using 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0209)): 0x41a1a7b3b8fe5596d9aa75d9c67042bfb299aa14473c4893b154145515101393
+cloak.plan(fyToken, join(02)): 0x1334c6e7bfdb432416afae20605e2b45db7001b1543a24fa25d9998073e8828d
+Updating 0x303130390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000 ilks
+addIlks 0109: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
+Updating 0x303230390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000 ilks
+addIlks 0209: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Timelock balance of 0x303100000000 is 145999585760000000000
+Transferring 100000000000000000000 of 0x303100000000 from Timelock to Pool
+Initializing FYDAI2209LP at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+Transferring 6000000000000000000 of 0x303100000000 from Timelock to Join
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Timelock balance of 0x303200000000 is 104000000
+Transferring 100000000 of 0x303200000000 from Timelock to Pool
+Initializing FYUSDC2209LP at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+Transferring 4000000 of 0x303200000000 from Timelock to Join
+Using strategy at 0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD for YSDAI6MMS
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Strategy YSDAI6MMS divested from 0x303130350000
+Strategy YSDAI6MMS rolled onto 0x303130390000
+Using strategy at 0xFBc322415CBC532b54749E31979a803009516b5D for YSUSDC6MMS
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Strategy YSUSDC6MMS divested from 0x303230350000
+Strategy YSUSDC6MMS rolled onto 0x303230390000
+Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
+Approving
+Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
+Approved 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries-3.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE for 0x303130390000
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
+Adding 0x303130390000 for 0x303100000000 using 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
+Adding 0x303130390000 pool to Ladle using 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0109)): 0x8af89d8f65ca9a27a2416d98942394bc6f89c6ee1d19ecda5185d9acc8c2f135
+cloak.plan(fyToken, join(01)): 0x80d6bb80bff661aae56e873f9bdcbf04977f2ffb2487abad722f36bb1a397265
+Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc for 0x303230390000
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
+Adding 0x303230390000 for 0x303200000000 using 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
+Adding 0x303230390000 pool to Ladle using 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0209)): 0x41a1a7b3b8fe5596d9aa75d9c67042bfb299aa14473c4893b154145515101393
+cloak.plan(fyToken, join(02)): 0x1334c6e7bfdb432416afae20605e2b45db7001b1543a24fa25d9998073e8828d
+Updating 0x303130390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000 ilks
+addIlks 0109: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
+Updating 0x303230390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000 ilks
+addIlks 0209: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Timelock balance of 0x303100000000 is 145999585760000000000
+Transferring 100000000000000000000 of 0x303100000000 from Timelock to Pool
+Initializing FYDAI2209LP at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
+Transferring 6000000000000000000 of 0x303100000000 from Timelock to Join
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Timelock balance of 0x303200000000 is 104000000
+Transferring 100000000 of 0x303200000000 from Timelock to Pool
+Initializing FYUSDC2209LP at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
+Transferring 4000000 of 0x303200000000 from Timelock to Join
+Using strategy at 0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD for YSDAI6MMS
+Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
+Strategy YSDAI6MMS divested from 0x303130350000
+Strategy YSDAI6MMS rolled onto 0x303130390000
+Using strategy at 0xFBc322415CBC532b54749E31979a803009516b5D for YSUSDC6MMS
+Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
+Strategy YSUSDC6MMS divested from 0x303230350000
+Strategy YSUSDC6MMS rolled onto 0x303230390000
+Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
+Executing
+Executed 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
++ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries.test.ts
+No need to generate any newer typings.
+ChainId: 1
+Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
+series: 0x303130390000
+vault: 0xfd42f74f003587c8d24eb75f
+posting 510692341789501043149 ENS out of 836745000000000000000000
+borrowing 5000000000000000000000 FYDAI2209
+posted and borrowed
+repaying 5000000000000000000000 FYDAI2209 and withdrawing 510692341789501043149 ENS
+repaid and withdrawn
+series: 0x303230390000
+vault: 0x543571eceb4b9d5f48bf9582
+posting 508844819666950884662 ENS out of 836745000000000000000000
+borrowing 5000000000 FYUSDC2209
+posted and borrowed
+repaying 5000000000 FYUSDC2209 and withdrawing 508844819666950884662 ENS
+repaid and withdrawn
+```
+
+The g1 and g2 values being set are as follows:
+```
+g1 set to 13835058055282163712
+g2 set to 24595658764946068821
+```
+
+The ts value being set are as follows:
+```
+ts set to 19484734869
+```

--- a/YPP-0031.md
+++ b/YPP-0031.md
@@ -2,7 +2,7 @@
 Deploy the fyToken and pool contracts for the DAI and USDC September series
 
 # Background
-On March 25th 2022 the FYDAI2203 and FYUSDC2203 series will mature, and the YSDAI6MMS and YSUSDC6MMS strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled.
+On March 25th 2022 the FYDAI2203 and FYUSDC2203 series will mature, and the YSDAI6MMS and YSUSDC6MMS strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled. The contracts would be activated after the maturity of previous pools by executing a separate transaction.
 
 # Details
 Here are the steps:

--- a/YPP-0031.md
+++ b/YPP-0031.md
@@ -1,5 +1,5 @@
 # Proposal
-Deploy the fyToken and pool contracts for the DAI and USDC September series
+Deploy the fyToken and pool contracts for the DAI and USDC September series & activate the series
 
 # Background
 On March 25th 2022 the FYDAI2203 and FYUSDC2203 series will mature, and the YSDAI6MMS and YSUSDC6MMS strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled. The contracts would be activated after the maturity of previous pools by executing a separate transaction.
@@ -265,6 +265,9 @@ Strategy YSUSDC6MMS rolled onto 0x303230390000
 Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
 Executing
 Executed 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
+```
+The following test was run on the forked mainnet to ensure that the protocol is working as expected:
+```
 + npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries.test.ts
 No need to generate any newer typings.
 ChainId: 1
@@ -294,4 +297,9 @@ g2 set to 24595658764946068821
 The ts value being set are as follows:
 ```
 ts set to 19484734869
+```
+
+Maturity of the series is set to:
+```
+EOSEPT22 = 1664550000 // Friday, Sep 30, 2022 3:00:00 PM GMT+00:00
 ```


### PR DESCRIPTION
# Proposal
Deploy the fyToken and pool contracts for the DAI and USDC September series & activate the series

# Background
On March 25th 2022 the FYDAI2203 and FYUSDC2203 series will mature, and the YSDAI6MMS and YSUSDC6MMS strategies will stop accruing fees. To prepare for the maturity and rollover, the fyToken and pool contracts can already be deployed. The fyToken contracts won't be able to mint any tokens yet, effectively keeping both contracts disabled. The contracts would be activated after the maturity of previous pools by executing a separate transaction.

# Details
Here are the steps:
1. Deploy fyToken contracts for FYDAI2209 & FYUSDC2209 (no need for governance approval)
2. Deploy pool contracts(no need for governance approval)
3. Governance proposal
    1. Add new series
    2. Add ilks to the new series
    3. Initialize new pools
    4. Roll the strategies to the next pool

We would be deploying the fyTokens & pools using the [deploySeptSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/deploySeptSeries.mainnet.sh), with [this input](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config.ts):

```
// Parameters to deploy fyToken with
// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
  [FYDAI2209, DAI, protocol.get(COMPOUND) as string, joins.get(DAI) as string, EOSEPT22, 'FYDAI2209', 'FYDAI2209'],
  [FYUSDC2209, USDC, protocol.get(COMPOUND) as string, joins.get(USDC) as string, EOSEPT22, 'FYUSDC2209', 'FYUSDC2209'],
]

// Parameters to deploy pools with, a pool being identified by the related seriesId
// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee), g2 (Sell fyToken to the pool fee)
export const poolData: Array<[string, string, string, BigNumber, BigNumber, BigNumber]> = [
  [
    FYDAI2209,
    assets.get(DAI) as string,
    fyTokens.get(FYDAI2209) as string,
    ONE64.div(secondsIn30Years),
    ONE64.mul(75).div(100),
    ONE64.mul(100).div(75),
  ],
  [
    FYUSDC2209,
    assets.get(USDC) as string,
    fyTokens.get(FYUSDC2209) as string,
    ONE64.div(secondsIn30Years),
    ONE64.mul(75).div(100),
    ONE64.mul(100).div(75),
  ],
]
```
We would be activating the series using [activateSeptSeries.mainnet.sh](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/activateSeptSeries.mainnet.sh) with [this input](https://github.com/yieldprotocol/environments-v2/blob/feat/roll-marchtosept-2022/scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config.ts)

```
// Amounts to initialize pools with, a pool being identified by the related seriesId
// seriesId, baseId, baseAmount, fyTokenAmount
export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
  [FYDAI2209, DAI, WAD.mul(100), BigNumber.from(0)],
  [FYUSDC2209, USDC, ONEUSDC.mul(100), BigNumber.from(0)],
]

// Ilks to accept for each series
// seriesId, accepted ilks
export const seriesIlks: Array<[string, string[]]> = [
  [FYDAI2209, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI]],
  [FYUSDC2209, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, YVUSDC]],
]

// Parameters to roll each strategy
// strategyId, nextSeriesId, minRatio, maxRatio
export const rollData: Array<[string, string, BigNumber, BigNumber]> = [
  [YSDAI6MMS, FYDAI2209, BigNumber.from(0), MAX256],
  [YSUSDC6MMS, FYUSDC2209, BigNumber.from(0), MAX256],
]
```

# Testing
The change has been deployed on a mainnet fork with the following output.
```
~/Documents/Crypto/Yield/environments-v2   feat/roll-marchtosept-2022 ● ⍟4  ./scripts/governance/addSeries/addSeptSeries/deploySeptSeries.mainnet.sh
++ dirname ./scripts/governance/addSeries/addSeptSeries/deploySeptSeries.mainnet.sh
+ HERE=./scripts/governance/addSeries/addSeptSeries
+ export CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config
+ CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/addSeries/addSeptSeries/addSeptSeries.mainnet.config
+ RUN='npx hardhat run --network localhost'
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/../../newEnvironment/deployFYTokens.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303130390000
Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303130390000
FYToken deployed at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
npx hardhat verify --network localhost 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE 0x303100000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc 1664550000 FYDAI2209 FYDAI2209 --libraries safeERC20Namer.js
fyToken.grantRoles(ROOT, timelock)
Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303230390000
Using oracle at 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c for 0x303230390000
FYToken deployed at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
npx hardhat verify --network localhost 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc 0x303200000000 0x53FBa816BD69a7f2a096f58687f87dd3020d0d5c 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 1664550000 FYUSDC2209 FYUSDC2209 --libraries safeERC20Namer.js
fyToken.grantRoles(ROOT, timelock)
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/../../newEnvironment/deployPools.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using base at 0x6B175474E89094C44Da98b954EedeAC495271d0F
Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
Pool deployed at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
npx hardhat verify --network localhost 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c 0x6B175474E89094C44Da98b954EedeAC495271d0F 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE 19484734869 13835058055282163712 24595658764946068821 --libraries yieldMath.js
Using base at 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
Pool deployed at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
npx hardhat verify --network localhost 0xefc1aB2475ACb7E60499Efb171D173be19928a05 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc 19484734869 13835058055282163712 24595658764946068821 --libraries yieldMath.js
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries-3.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE for 0x303130390000
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
Adding 0x303130390000 for 0x303100000000 using 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
Adding 0x303130390000 pool to Ladle using 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0109)): 0x8af89d8f65ca9a27a2416d98942394bc6f89c6ee1d19ecda5185d9acc8c2f135
cloak.plan(fyToken, join(01)): 0x80d6bb80bff661aae56e873f9bdcbf04977f2ffb2487abad722f36bb1a397265
Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc for 0x303230390000
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
Adding 0x303230390000 for 0x303200000000 using 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
Adding 0x303230390000 pool to Ladle using 0xefc1aB2475ACb7E60499Efb171D173be19928a05
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0209)): 0x41a1a7b3b8fe5596d9aa75d9c67042bfb299aa14473c4893b154145515101393
cloak.plan(fyToken, join(02)): 0x1334c6e7bfdb432416afae20605e2b45db7001b1543a24fa25d9998073e8828d
Updating 0x303130390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000 ilks
addIlks 0109: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
Updating 0x303230390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000 ilks
addIlks 0209: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Timelock balance of 0x303100000000 is 145999585760000000000
Transferring 100000000000000000000 of 0x303100000000 from Timelock to Pool
Initializing FYDAI2209LP at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
Transferring 6000000000000000000 of 0x303100000000 from Timelock to Join
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Timelock balance of 0x303200000000 is 104000000
Transferring 100000000 of 0x303200000000 from Timelock to Pool
Initializing FYUSDC2209LP at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
Transferring 4000000 of 0x303200000000 from Timelock to Join
Using strategy at 0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD for YSDAI6MMS
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Strategy YSDAI6MMS divested from 0x303130350000
Strategy YSDAI6MMS rolled onto 0x303130390000
Using strategy at 0xFBc322415CBC532b54749E31979a803009516b5D for YSUSDC6MMS
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Strategy YSUSDC6MMS divested from 0x303230350000
Strategy YSUSDC6MMS rolled onto 0x303230390000
Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
Proposing
Proposed 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries-3.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE for 0x303130390000
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
Adding 0x303130390000 for 0x303100000000 using 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
Adding 0x303130390000 pool to Ladle using 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0109)): 0x8af89d8f65ca9a27a2416d98942394bc6f89c6ee1d19ecda5185d9acc8c2f135
cloak.plan(fyToken, join(01)): 0x80d6bb80bff661aae56e873f9bdcbf04977f2ffb2487abad722f36bb1a397265
Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc for 0x303230390000
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
Adding 0x303230390000 for 0x303200000000 using 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
Adding 0x303230390000 pool to Ladle using 0xefc1aB2475ACb7E60499Efb171D173be19928a05
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0209)): 0x41a1a7b3b8fe5596d9aa75d9c67042bfb299aa14473c4893b154145515101393
cloak.plan(fyToken, join(02)): 0x1334c6e7bfdb432416afae20605e2b45db7001b1543a24fa25d9998073e8828d
Updating 0x303130390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000 ilks
addIlks 0109: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
Updating 0x303230390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000 ilks
addIlks 0209: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Timelock balance of 0x303100000000 is 145999585760000000000
Transferring 100000000000000000000 of 0x303100000000 from Timelock to Pool
Initializing FYDAI2209LP at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
Transferring 6000000000000000000 of 0x303100000000 from Timelock to Join
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Timelock balance of 0x303200000000 is 104000000
Transferring 100000000 of 0x303200000000 from Timelock to Pool
Initializing FYUSDC2209LP at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
Transferring 4000000 of 0x303200000000 from Timelock to Join
Using strategy at 0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD for YSDAI6MMS
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Strategy YSDAI6MMS divested from 0x303130350000
Strategy YSDAI6MMS rolled onto 0x303130390000
Using strategy at 0xFBc322415CBC532b54749E31979a803009516b5D for YSUSDC6MMS
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Strategy YSUSDC6MMS divested from 0x303230350000
Strategy YSUSDC6MMS rolled onto 0x303230390000
Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
Approving
Running on a fork, impersonating multisig at 0xd659565b84bcfcb23b02ee13e46cb51429f4558a
Approved 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries-3.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
Using fyToken at 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE for 0x303130390000
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Using join at 0x4fE92119CDf873Cf8826F4E6EcfD4E578E3D44Dc for 0x303100000000
Adding 0x303130390000 for 0x303100000000 using 0x4bf010f1b9beDA5450a8dD702ED602A104ff65EE
Adding 0x303130390000 pool to Ladle using 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0109)): 0x8af89d8f65ca9a27a2416d98942394bc6f89c6ee1d19ecda5185d9acc8c2f135
cloak.plan(fyToken, join(01)): 0x80d6bb80bff661aae56e873f9bdcbf04977f2ffb2487abad722f36bb1a397265
Using fyToken at 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc for 0x303230390000
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Using join at 0x0d9A1A773be5a83eEbda23bf98efB8585C3ae4f4 for 0x303200000000
Adding 0x303230390000 for 0x303200000000 using 0x96F3Ce39Ad2BfDCf92C0F6E2C2CAbF83874660Fc
Adding 0x303230390000 pool to Ladle using 0xefc1aB2475ACb7E60499Efb171D173be19928a05
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0209)): 0x41a1a7b3b8fe5596d9aa75d9c67042bfb299aa14473c4893b154145515101393
cloak.plan(fyToken, join(02)): 0x1334c6e7bfdb432416afae20605e2b45db7001b1543a24fa25d9998073e8828d
Updating 0x303130390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000 ilks
addIlks 0109: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000
Updating 0x303230390000 series with 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000 ilks
addIlks 0209: 0x303000000000,0x303100000000,0x303200000000,0x303300000000,0x303400000000,0x303600000000,0x303700000000,0x313000000000,0x303900000000
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Timelock balance of 0x303100000000 is 145999585760000000000
Transferring 100000000000000000000 of 0x303100000000 from Timelock to Pool
Initializing FYDAI2209LP at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c
Transferring 6000000000000000000 of 0x303100000000 from Timelock to Join
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Timelock balance of 0x303200000000 is 104000000
Transferring 100000000 of 0x303200000000 from Timelock to Pool
Initializing FYUSDC2209LP at 0xefc1aB2475ACb7E60499Efb171D173be19928a05
Transferring 4000000 of 0x303200000000 from Timelock to Join
Using strategy at 0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD for YSDAI6MMS
Using pool at 0xde2Bd2ffEA002b8E84ADeA96e5976aF664115E2c for 0x303130390000
Strategy YSDAI6MMS divested from 0x303130350000
Strategy YSDAI6MMS rolled onto 0x303130390000
Using strategy at 0xFBc322415CBC532b54749E31979a803009516b5D for YSUSDC6MMS
Using pool at 0xefc1aB2475ACb7E60499Efb171D173be19928a05 for 0x303230390000
Strategy YSUSDC6MMS divested from 0x303230350000
Strategy YSUSDC6MMS rolled onto 0x303230390000
Proposal: 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
Executing
Executed 0xbd45a4526c918fb712d05943b85f72a0bf744e786c393f1c4aad9164c6f8c216
```
The following test was run on the forked mainnet to ensure that the protocol is working as expected:
```
+ npx hardhat run --network localhost ./scripts/governance/addSeries/addSeptSeries/addSeptSeries.test.ts
No need to generate any newer typings.
ChainId: 1
Running on a fork, impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8
series: 0x303130390000
vault: 0xfd42f74f003587c8d24eb75f
posting 510692341789501043149 ENS out of 836745000000000000000000
borrowing 5000000000000000000000 FYDAI2209
posted and borrowed
repaying 5000000000000000000000 FYDAI2209 and withdrawing 510692341789501043149 ENS
repaid and withdrawn
series: 0x303230390000
vault: 0x543571eceb4b9d5f48bf9582
posting 508844819666950884662 ENS out of 836745000000000000000000
borrowing 5000000000 FYUSDC2209
posted and borrowed
repaying 5000000000 FYUSDC2209 and withdrawing 508844819666950884662 ENS
repaid and withdrawn
```

The g1 and g2 values being set are as follows:
```
g1 set to 13835058055282163712
g2 set to 24595658764946068821
```

The ts value being set are as follows:
```
ts set to 19484734869
```

Maturity of the series is set to:
```
EOSEPT22 = 1664550000 // Friday, Sep 30, 2022 3:00:00 PM GMT+00:00
```