### PR TITLE
Fix FRAX/FRAX dust

### DIFF
--- a/YPP-0035.md
+++ b/YPP-0035.md
@@ -5,7 +5,7 @@ Drop the dust level for FRAX/FRAX borrowings to zero
 The dust level for borrowing an fyToken with its underlying must be set to zero, to allow "Borrow and Pool". This is safe because these positions are not liquidable. By error the dust level was set at 5000 for FRAX/FRAX.
 
 # Details
-The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/3b3425137007ea5c81e7466099ea3b187db3343c/scripts/governance/updateDust/updateDust.ts) script will be used, with this input:
+The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust/updateDust.ts) script will be used, with this [input](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust.mainnet.config):
 ```
 // Input data: baseId, ilkId, dust
 export const newMin: Array<[string, string, number]> = [
@@ -14,7 +14,7 @@ export const newMin: Array<[string, string, number]> = [
 
 ```
 # Testing
-The change has been tested on a mainnet fork by running [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/3b3425137007ea5c81e7466099ea3b187db3343c/scripts/governance/updateDust/updateDust.ts) first, followed by [updateDust.test.ts](https://github.com/yieldprotocol/environments-v2/blob/3b3425137007ea5c81e7466099ea3b187db3343c/scripts/governance/updateDust/updateDust.test.ts) to verify that the changes were made.
+The change has been tested on a mainnet fork by running [updateDust.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust/updateDust.ts) first, followed by [updateDust.test.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust/updateDust.test.ts) to verify that the changes were made.
 ```
 + npx hardhat run --network localhost ./scripts/governance/updateDust/updateDust.ts
 No need to generate any newer typings.

--- a/YPP-0035.md
+++ b/YPP-0035.md
@@ -5,7 +5,7 @@ Drop the dust level for FRAX/FRAX borrowings to zero
 The dust level for borrowing an fyToken with its underlying must be set to zero, to allow "Borrow and Pool". This is safe because these positions are not liquidable. By error the dust level was set at 5000 for FRAX/FRAX.
 
 # Details
-The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust/updateDust.ts) script will be used, with this [input](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust.mainnet.config):
+The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.ts) script will be used, with this [input](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.mainnet.config):
 ```
 // Input data: baseId, ilkId, dust
 export const newMin: Array<[string, string, number]> = [
@@ -14,7 +14,7 @@ export const newMin: Array<[string, string, number]> = [
 
 ```
 # Testing
-The change has been tested on a mainnet fork by running [updateDust.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust/updateDust.ts) first, followed by [updateDust.test.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/frax-series/scripts/governance/updateDust/updateDust.test.ts) to verify that the changes were made.
+The change has been tested on a mainnet fork by running [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.mainnet.config.ts) first, followed by [updateDust.test.ts](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.test.ts) to verify that the changes were made.
 ```
 + npx hardhat run --network localhost ./scripts/governance/updateDust/updateDust.ts
 No need to generate any newer typings.

--- a/YPP-0035.md
+++ b/YPP-0035.md
@@ -9,7 +9,7 @@ The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/tree/feat/f
 ```
 // Input data: baseId, ilkId, dust
 export const newMin: Array<[string, string, number]> = [
-  [FRAX,  FRAX,    5000],
+  [FRAX,  FRAX,  0],
 ]
 
 ```

--- a/YPP-0035.md
+++ b/YPP-0035.md
@@ -1,0 +1,28 @@
+# Proposal
+Drop the dust level for FRAX/FRAX borrowings to zero
+
+# Background
+The dust level for borrowing an fyToken with its underlying must be set to zero, to allow "Borrow and Pool". This is safe because these positions are not liquidable. By error the dust level was set at 5000 for FRAX/FRAX.
+
+# Details
+The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/3b3425137007ea5c81e7466099ea3b187db3343c/scripts/governance/updateDust/updateDust.ts) script will be used, with this input:
+```
+// Input data: baseId, ilkId, dust
+export const newMin: Array<[string, string, number]> = [
+  [FRAX,  FRAX,    5000],
+]
+
+```
+# Testing
+The change has been tested on a mainnet fork by running [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/3b3425137007ea5c81e7466099ea3b187db3343c/scripts/governance/updateDust/updateDust.ts) first, followed by [updateDust.test.ts](https://github.com/yieldprotocol/environments-v2/blob/3b3425137007ea5c81e7466099ea3b187db3343c/scripts/governance/updateDust/updateDust.test.ts) to verify that the changes were made.
+```
++ npx hardhat run --network localhost ./scripts/governance/updateDust/updateDust.ts
+No need to generate any newer typings.
+18/18: 5000 -> 0
+Proposal: 0xb47f583ad07854ab566decb227b12c40bb44e32eaa9a59fc29abe76994773e61
+Executing
+Executed 0xb47f583ad07854ab566decb227b12c40bb44e32eaa9a59fc29abe76994773e61
++ npx hardhat run --network localhost ./scripts/governance/updateDust/updateDust.test.ts
+No need to generate any newer typings.
+18/18 set: 0
+```


### PR DESCRIPTION
# Proposal
Drop the dust level for FRAX/FRAX borrowings to zero

# Background
The dust level for borrowing an fyToken with its underlying must be set to zero, to allow "Borrow and Pool". This is safe because these positions are not liquidable. By error the dust level was set at 5000 for FRAX/FRAX.

# Details
The [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.ts) script will be used, with this [input](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.mainnet.config):
```
// Input data: baseId, ilkId, dust
export const newMin: Array<[string, string, number]> = [
  [FRAX,  FRAX,  0],
]

```
# Testing
The change has been tested on a mainnet fork by running [updateDust.ts](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.mainnet.config.ts) first, followed by [updateDust.test.ts](https://github.com/yieldprotocol/environments-v2/blob/ae229419a05c4243d2e21593fa209a1b7db0ca57/scripts/governance/updateDust/updateDust.test.ts) to verify that the changes were made.
```
+ npx hardhat run --network localhost ./scripts/governance/updateDust/updateDust.ts
No need to generate any newer typings.
18/18: 5000 -> 0
Proposal: 0xb47f583ad07854ab566decb227b12c40bb44e32eaa9a59fc29abe76994773e61
Executing
Executed 0xb47f583ad07854ab566decb227b12c40bb44e32eaa9a59fc29abe76994773e61
+ npx hardhat run --network localhost ./scripts/governance/updateDust/updateDust.test.ts
No need to generate any newer typings.
18/18 set: 0
```