### PR TITLE
Fix auction proportions

### DIFF
--- a/YPP-0037.md
+++ b/YPP-0037.md
@@ -1,0 +1,30 @@
+# Proposal
+Set the initial offer for all assets with 18 decimals. Raise the auction limits for all assets.
+
+# Background
+The initial proportion for all assets was set with 6 decimals, when it needs 18, effectively rendering the first two thirds of any auction uneconomical, and compressing the auction into the last third.
+
+# Details
+The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/update/updateAuctions/updateAuctions.ts) script will be used, with this input:
+```
+/// @notice Limits to be used in an auction
+/// @param base identifier (bytes6 tag)
+/// @param initial percentage of the collateral to be offered (fixed point with 6 decimals)
+/// @param Maximum concurrently auctionable for this asset, modified by decimals
+/// @param Minimum vault debt, modified by decimals
+/// @param Decimals to append to auction ceiling and minimum vault debt.
+export const newLimits: Array<[string, string, number, number, number]> = [
+  [ETH,    '666000000000000000', 32500000000, 1500000, 12],
+  [DAI,    '714000000000000000', 100000000,   5000,    18],
+  [USDC,   '714000000000000000', 100000000,   5000,    6],
+  [WBTC,   '666000000000000000', 25000000,    1200,    4],
+  [WSTETH, '666000000000000000', 32500000000, 1500000, 12],
+  [LINK,   '600000000000000000', 6000000,     300,     18],
+  [ENS,    '600000000000000000', 5000000,     250,     18],
+  [YVUSDC, '800000000000000000', 10000000,    5000,    6],
+  [UNI,    '600000000000000000', 10000000,    400,     18],
+  [FRAX,   '714000000000000000', 100000000,   400,     18],
+]
+```
+# Testing
+The change has been deployed to a [mainnet fork](https://dashboard.tenderly.co/Yield/v2/fork/32e736c2-9d6f-4dc8-ab91-ccb4f69d4d0c) where the data can be verified.


### PR DESCRIPTION
# Proposal
Set the initial offer for all assets with 18 decimals. Raise the auction limits for all assets.

# Background
The initial proportion for all assets was set with 6 decimals, when it needs 18, effectively rendering the first two thirds of any auction uneconomical, and compressing the auction into the last third.

# Details
The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/update/updateAuctions/updateAuctions.ts) script will be used, with this input:
```
/// @notice Limits to be used in an auction
/// @param base identifier (bytes6 tag)
/// @param initial percentage of the collateral to be offered (fixed point with 6 decimals)
/// @param Maximum concurrently auctionable for this asset, modified by decimals
/// @param Minimum vault debt, modified by decimals
/// @param Decimals to append to auction ceiling and minimum vault debt.
export const newLimits: Array<[string, string, number, number, number]> = [
  [ETH,    '666000000000000000', 32500000000, 1500000, 12],
  [DAI,    '714000000000000000', 100000000,   5000,    18],
  [USDC,   '714000000000000000', 100000000,   5000,    6],
  [WBTC,   '666000000000000000', 25000000,    1200,    4],
  [WSTETH, '666000000000000000', 32500000000, 1500000, 12],
  [LINK,   '600000000000000000', 6000000,     300,     18],
  [ENS,    '600000000000000000', 5000000,     250,     18],
  [YVUSDC, '800000000000000000', 10000000,    5000,    6],
  [UNI,    '600000000000000000', 10000000,    400,     18],
  [FRAX,   '714000000000000000', 100000000,   400,     18],
]
```
# Testing
The change has been deployed to a [mainnet fork](https://dashboard.tenderly.co/Yield/v2/fork/32e736c2-9d6f-4dc8-ab91-ccb4f69d4d0c) where the data can be verified.
