### PR TITLE
Auction parameters in Arbitrum

### DIFF
--- a/YPP-0039.md
+++ b/YPP-0039.md
@@ -5,7 +5,7 @@ Set the initial offer for all assets in Arbitrum with 18 decimals. Raise the auc
 The initial proportion for all assets was set with 6 decimals, when it needs 18, effectively rendering the first two thirds of any auction uneconomical, and compressing the auction into the last third.
 
 # Details
-The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/update/updateAuctions/updateAuctions.ts) script will be used, with this input:
+The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/73bb47bb75913c234e977283737b1bb3685e6dce/scripts/governance/update/updateAuctions/updateAuctions.ts) script will be used, with this input:
 ```
 /// @notice Limits to be used in an auction
 /// @param base identifier (bytes6 tag)

--- a/YPP-0039.md
+++ b/YPP-0039.md
@@ -1,0 +1,26 @@
+# Proposal
+Set the initial offer for all assets in Arbitrum with 18 decimals. Raise the auction limits for all assets.
+
+# Background
+The initial proportion for all assets was set with 6 decimals, when it needs 18, effectively rendering the first two thirds of any auction uneconomical, and compressing the auction into the last third.
+
+# Details
+The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/4bf6c0f8a2576da54d660e28679ff3c0104e4603/scripts/governance/update/updateAuctions/updateAuctions.ts) script will be used, with this input:
+```
+/// @notice Limits to be used in an auction
+/// @param base identifier (bytes6 tag)
+/// @param initial percentage of the collateral to be offered (fixed point with 6 decimals)
+/// @param Maximum concurrently auctionable for this asset, modified by decimals
+/// @param Minimum vault debt, modified by decimals
+/// @param Decimals to append to auction ceiling and minimum vault debt.
+export const newLimits: Array<[string, string, number, number, number]> = [
+  [ETH,    '720000000000000000', 32500000000, 30000, 12], // DAI/ETH is 72% LTV
+  [DAI,    '760000000000000000', 100000000,   100,   18], // USDC/DAI is 76% LTV
+  [USDC,   '760000000000000000', 100000000,   100,   6],  // DAI/USDC is 76% LTV
+]
+```
+
+The initial proportion has been set to the highest LTV for a pair in which the asset is a collateral, to ensure that all auctions start at market price or lower and are liquidable immediately.
+
+# Testing
+Manual verification.


### PR DESCRIPTION
# Proposal
Set the initial offer for all assets in Arbitrum with 18 decimals. Raise the auction limits for all assets.

# Background
The initial proportion for all assets was set with 6 decimals, when it needs 18, effectively rendering the first two thirds of any auction uneconomical, and compressing the auction into the last third.

# Details
The [updateAuctions.ts](https://github.com/yieldprotocol/environments-v2/blob/73bb47bb75913c234e977283737b1bb3685e6dce/scripts/governance/update/updateAuctions/updateAuctions.ts) script will be used, with this input:
```
/// @notice Limits to be used in an auction
/// @param base identifier (bytes6 tag)
/// @param initial percentage of the collateral to be offered (fixed point with 6 decimals)
/// @param Maximum concurrently auctionable for this asset, modified by decimals
/// @param Minimum vault debt, modified by decimals
/// @param Decimals to append to auction ceiling and minimum vault debt.
export const newLimits: Array<[string, string, number, number, number]> = [
  [ETH,    '720000000000000000', 32500000000, 30000, 12], // DAI/ETH is 72% LTV
  [DAI,    '760000000000000000', 100000000,   100,   18], // USDC/DAI is 76% LTV
  [USDC,   '760000000000000000', 100000000,   100,   6],  // DAI/USDC is 76% LTV
]
```

The initial proportion has been set to the highest LTV for a pair in which the asset is a collateral, to ensure that all auctions start at market price or lower and are liquidable immediately.

# Testing
Manual verification.
