### PR TITLE
Update ETH limits

### DIFF
--- a/YPP-0044.md
+++ b/YPP-0044.md
@@ -34,4 +34,4 @@ export const newLimits: Array<[string, string, number, number, number]> = [
 ```
 
 # Testing
-TBA
+[Tenderly Fork](https://dashboard.tenderly.co/Yield/v2/fork/f0f10e78-2ed2-4ab7-9b66-f1211993b2d4/simulation/e2ad5dfa-8f2f-4f74-9ce2-4f5c58078719)

--- a/YPP-0044.md
+++ b/YPP-0044.md
@@ -1,0 +1,37 @@
+# Proposal
+Increase the minimum vault debt parameters for borrowing ETH with any collateral.
+Increase the global debt limit for borrowing ETH with FRAX as collateral.
+These changes are only required on mainnet.
+
+# Background
+By mistake these have been set too low. Minimum vault debt must be equivalent to $5000. Gobal debt for borrowing ETH with FRAX can be raised to 250 ETH.
+
+# Details
+To avoid further mistakes of this sense, `debt.dec` will be set to 18 to match the decimals of ETH, so that errors can be more easily spotted.
+
+Governance scripts can be found [here](https://github.com/yieldprotocol/environments-v2/tree/feat/update-limits/scripts/governance/update/updateLimits) for those with appropriate permissioning.
+
+Configuration (mainnet):
+```
+/// @notice Limits to be used in an auction
+/// @param base identifier (bytes6 tag)
+/// @param ilk identifier (bytes6 tag)
+/// @param Maximum global debt allowed for this pair, modified by decimals
+/// @param Minimum vault debt allowed for this pair, modified by decimals
+/// @param Decimals to append to global and vault debt.
+export const newLimits: Array<[string, string, number, number, number]> = [
+  [ETH, ETH, 2500, 0, 18],
+  [ETH, DAI, 250, 3, 18],
+  [ETH, USDC, 250, 3, 18],
+  [ETH, WBTC, 250, 3, 18],
+  [ETH, WSTETH, 250, 3, 18],
+  [ETH, LINK, 250, 3, 18],
+  [ETH, ENS, 250, 3, 18],
+  [ETH, YVUSDC, 0, 0, 18],
+  [ETH, UNI, 250, 3, 18],
+  [ETH, FRAX, 250, 3, 18],
+]
+```
+
+# Testing
+TBA


### PR DESCRIPTION
# Proposal
Increase the minimum vault debt parameters for borrowing ETH with any collateral.
Increase the global debt limit for borrowing ETH with FRAX as collateral.
These changes are only required on mainnet.

# Background
By mistake these have been set too low. Minimum vault debt must be equivalent to $5000. Gobal debt for borrowing ETH with FRAX can be raised to 250 ETH.

# Details
To avoid further mistakes of this sense, `debt.dec` will be set to 18 to match the decimals of ETH, so that errors can be more easily spotted.

Governance scripts can be found [here](https://github.com/yieldprotocol/environments-v2/tree/feat/update-limits/scripts/governance/update/updateLimits) for those with appropriate permissioning.

Configuration (mainnet):
```
/// @notice Limits to be used in an auction
/// @param base identifier (bytes6 tag)
/// @param ilk identifier (bytes6 tag)
/// @param Maximum global debt allowed for this pair, modified by decimals
/// @param Minimum vault debt allowed for this pair, modified by decimals
/// @param Decimals to append to global and vault debt.
export const newLimits: Array<[string, string, number, number, number]> = [
  [ETH, ETH, 2500, 0, 18],
  [ETH, DAI, 250, 3, 18],
  [ETH, USDC, 250, 3, 18],
  [ETH, WBTC, 250, 3, 18],
  [ETH, WSTETH, 250, 3, 18],
  [ETH, LINK, 250, 3, 18],
  [ETH, ENS, 250, 3, 18],
  [ETH, YVUSDC, 0, 0, 18],
  [ETH, UNI, 250, 3, 18],
  [ETH, FRAX, 250, 3, 18],
]
```

# Testing
[Tenderly Fork](https://dashboard.tenderly.co/Yield/v2/fork/f0f10e78-2ed2-4ab7-9b66-f1211993b2d4/simulation/e2ad5dfa-8f2f-4f74-9ce2-4f5c58078719)