### PR TITLE
June roll Arbitrum

### DIFF
--- a/YPP-0045.md
+++ b/YPP-0045.md
@@ -1,0 +1,89 @@
+# Proposal
+Activate the DAI and USDC December series on mainnet using yieldspace-tv, and roll the respective strategies from June to December
+
+# Background
+On June 24th 2022 all June series matured, and the YSDAI6MMS and YSUSDC6MMS strategies stopped accruing fees. New yieldspace-tv pools are going to be used for the December series, without any underlying yield-bearing token as there is none suitable in Arbitrum.
+
+# Details
+Here are the steps:
+1. Deploy Roller to use flash loans if the Joins don't have enough assets to redeem all fyToken in the rolled pools.
+2. Deploy fyToken contracts for FYDAI2212 and FYUSDC2212.
+3. Deploy respective pool contracts.
+4. Governance proposal
+    1. Orchestrate pools
+    2. Orchestrate roller
+    3. Add new series
+    4. Add ilks to the new series
+    5. Initialize new pools
+    6. Roll the strategies to the next pool
+
+We would be deploying the fyTokens & pools using the [add script link](), with [add config link]():
+
+```
+// Time stretch to be set in the PoolFactory prior to pool deployment
+export const timeStretch: Map<string, BigNumber> = new Map([
+  [FYDAI2212, ONE64.div(secondsInOneYear.mul(45))],
+  [FYUSDC2212, ONE64.div(secondsInOneYear.mul(55))],
+])
+
+// Sell base to the pool fee, as fp4
+export const g1: number = 9000
+
+// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
+export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
+  [FYDAI2212, DAI, protocol.get(ACCUMULATOR) as string, joins.get(DAI) as string, EODEC22, 'FYDAI2212', 'FYDAI2212'],
+  [FYUSDC2212, USDC, protocol.get(ACCUMULATOR) as string, joins.get(USDC) as string, EODEC22, 'FYUSDC2212', 'FYUSDC2212'],
+]
+
+// Parameters to deploy pools with, a pool being identified by the related seriesId
+// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee)
+export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
+  [
+    FYDAI2212,
+    assets.get(DAI) as string,
+    newFYTokens.get(FYDAI2212) as string,
+    timeStretch.get(FYDAI2212) as BigNumber,
+    g1,
+  ],
+  [
+    FYUSDC2212,
+    assets.get(USDC) as string,
+    newFYTokens.get(FYUSDC2212) as string,
+    timeStretch.get(FYUSDC2212) as BigNumber,
+    g1,
+  ],
+]
+
+// Amounts to initialize pools with, a pool being identified by the related seriesId
+// seriesId, initAmount
+export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
+  [FYDAI2212, DAI, WAD.mul(100), BigNumber.from('0')],
+  [FYUSDC2212, USDC, ONEUSDC.mul(100), BigNumber.from('0')],
+]
+
+// Amount to loan to the Joins in forks. On mainnet, someone will need to deposit into a vault
+// assetId, loanAmount
+export const joinLoans: Array<[string, BigNumber]> = [
+]
+
+// Ilks to accept for each series
+// seriesId, accepted ilks
+export const seriesIlks: Array<[string, string[]]> = [
+  [FYDAI2212, [ETH, DAI, USDC]],
+  [FYUSDC2212, [ETH, DAI, USDC]],
+]
+
+/// Parameters to roll each strategy
+/// @param strategyId
+/// @param nextSeriesId
+/// @param buffer Amount of base sent to the Roller to make up for market losses when using a flash loan for rolling
+/// @param lender ERC3156 flash lender used for rolling
+/// @param fix If true, transfer one base wei to the pool to allow the Strategy to start enhanced TV pools
+export const rollData: Array<[string, string, BigNumber, string, boolean]> = [
+  [YSDAI6MJD, FYDAI2212, ZERO, ZERO_ADDRESS, false],
+  [YSUSDC6MJD, FYUSDC2212, ZERO, ZERO_ADDRESS, false],
+]
+```
+
+# Testing
+The change has been deployed on a tenderly mainnet forks [add link to fork]() and tested using this process [add link to test spreadsheet]()


### PR DESCRIPTION
# Proposal
Activate the DAI and USDC December series on mainnet using yieldspace-tv, and roll the respective strategies from June to December

# Background
On June 24th 2022 all June series matured, and the YSDAI6MMS and YSUSDC6MMS strategies stopped accruing fees. New yieldspace-tv pools are going to be used for the December series, without any underlying yield-bearing token as there is none suitable in Arbitrum.

# Details
Here are the steps:
1. Deploy Roller to use flash loans if the Joins don't have enough assets to redeem all fyToken in the rolled pools.
2. Deploy fyToken contracts for FYDAI2212 and FYUSDC2212.
3. Deploy respective pool contracts.
4. Governance proposal
    1. Orchestrate pools
    2. Orchestrate roller
    3. Add new series
    4. Add ilks to the new series
    5. Initialize new pools
    6. Roll the strategies to the next pool

We would be deploying the fyTokens & pools using the [add script link](), with [add config link]():

```
// Time stretch to be set in the PoolFactory prior to pool deployment
export const timeStretch: Map<string, BigNumber> = new Map([
  [FYDAI2212, ONE64.div(secondsInOneYear.mul(45))],
  [FYUSDC2212, ONE64.div(secondsInOneYear.mul(55))],
])

// Sell base to the pool fee, as fp4
export const g1: number = 9000

// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
  [FYDAI2212, DAI, protocol.get(ACCUMULATOR) as string, joins.get(DAI) as string, EODEC22, 'FYDAI2212', 'FYDAI2212'],
  [FYUSDC2212, USDC, protocol.get(ACCUMULATOR) as string, joins.get(USDC) as string, EODEC22, 'FYUSDC2212', 'FYUSDC2212'],
]

// Parameters to deploy pools with, a pool being identified by the related seriesId
// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee)
export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
  [
    FYDAI2212,
    assets.get(DAI) as string,
    newFYTokens.get(FYDAI2212) as string,
    timeStretch.get(FYDAI2212) as BigNumber,
    g1,
  ],
  [
    FYUSDC2212,
    assets.get(USDC) as string,
    newFYTokens.get(FYUSDC2212) as string,
    timeStretch.get(FYUSDC2212) as BigNumber,
    g1,
  ],
]

// Amounts to initialize pools with, a pool being identified by the related seriesId
// seriesId, initAmount
export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
  [FYDAI2212, DAI, WAD.mul(100), BigNumber.from('0')],
  [FYUSDC2212, USDC, ONEUSDC.mul(100), BigNumber.from('0')],
]

// Amount to loan to the Joins in forks. On mainnet, someone will need to deposit into a vault
// assetId, loanAmount
export const joinLoans: Array<[string, BigNumber]> = [
]

// Ilks to accept for each series
// seriesId, accepted ilks
export const seriesIlks: Array<[string, string[]]> = [
  [FYDAI2212, [ETH, DAI, USDC]],
  [FYUSDC2212, [ETH, DAI, USDC]],
]

/// Parameters to roll each strategy
/// @param strategyId
/// @param nextSeriesId
/// @param buffer Amount of base sent to the Roller to make up for market losses when using a flash loan for rolling
/// @param lender ERC3156 flash lender used for rolling
/// @param fix If true, transfer one base wei to the pool to allow the Strategy to start enhanced TV pools
export const rollData: Array<[string, string, BigNumber, string, boolean]> = [
  [YSDAI6MJD, FYDAI2212, ZERO, ZERO_ADDRESS, false],
  [YSUSDC6MJD, FYUSDC2212, ZERO, ZERO_ADDRESS, false],
]
```

# Testing
The change has been deployed on a tenderly mainnet forks [add link to fork]() and tested using this process [add link to test spreadsheet]()