### PR TITLE
Add Egill as a developer

### DIFF
--- a/YPP-0046.md
+++ b/YPP-0046.md
@@ -1,0 +1,15 @@
+# Proposal
+Give developer roles on mainnet and arbitrum to 0x02f73B54ccfBA5c91bf432087D60e4b3a781E497, controlled by @egillh210.
+
+# Background
+Contango are building on top of us and a developer role will allow them and us to be more efficient.
+
+# Details
+
+The (addDevelopers)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts] script will be used, with (this input)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts].
+
+```
+export const newDevelopers: string[] = [
+    '0x02f73B54ccfBA5c91bf432087D60e4b3a781E497'
+]
+```


### PR DESCRIPTION
# Proposal
Give developer roles on mainnet and arbitrum to 0x02f73B54ccfBA5c91bf432087D60e4b3a781E497, controlled by @egillh210.

# Background
Contango are building on top of us and a developer role will allow them and us to be more efficient.

# Details

The (addDevelopers)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts] script will be used, with (this input)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts].

```
export const newDevelopers: string[] = [
    '0x02f73B54ccfBA5c91bf432087D60e4b3a781E497'
]
```