### PR TITLE
Give direct access to the multisig to isolate and restore

### DIFF
--- a/YPP-0047.md
+++ b/YPP-0047.md
@@ -1,0 +1,11 @@
+# Proposal
+Give permission to the multisig to `execute` and `restore` on the Cloak (EmergencyBrake), bypassing the Timelock. Both on Mainnet and Arbitrum.
+
+# Background
+To bring back a contract after isolating it it requires a governance proposal, subject to a Timelock delay. Past experiences show that this makes us less ready to isolate contracts and put the protocol in a safe situation, incurring undue risks.
+
+# Details
+The multisig addresses are `` and `` for mainnet and arbitrum respectively. The signatures for `execute(bytes32)` and `restore(bytes32)` are `0xe751f271` and `0x205e8d53` respectively. [Proof](https://sig.eth.samczsun.com).
+
+# Testing
+The change has been deployed on a [tenderly mainnet fork](https://dashboard.tenderly.co/Yield/v2/fork/45fc251f-fd4f-479c-aba8-cdfc9bb82653) and [tenderly arbitrum fork]. The events on the `execute` transaction show which permissions were given. The state change diff shows there is nothing else in the proposal.


### PR DESCRIPTION
# Proposal
Give permission to the multisig to `execute` and `restore` on the Cloak (EmergencyBrake), bypassing the Timelock. Both on Mainnet and Arbitrum.

# Background
To bring back a contract after isolating it it requires a governance proposal, subject to a Timelock delay. Past experiences show that this makes us less ready to isolate contracts and put the protocol in a safe situation, incurring undue risks.

# Details
The multisig addresses are `` and `` for mainnet and arbitrum respectively. The signatures for `execute(bytes32)` and `restore(bytes32)` are `0xe751f271` and `0x205e8d53` respectively. [Proof](https://sig.eth.samczsun.com).

# Testing
The change has been deployed on a [tenderly mainnet fork](https://dashboard.tenderly.co/Yield/v2/fork/45fc251f-fd4f-479c-aba8-cdfc9bb82653) and [tenderly arbitrum fork]. The events on the `execute` transaction show which permissions were given. The state change diff shows there is nothing else in the proposal.