### PR TITLE
Set pool fees to zero proposal

### DIFF
--- a/YPP-0048.md
+++ b/YPP-0048.md
@@ -1,0 +1,14 @@
+# Proposal
+Set pool fees to zero on all mainnet pools.
+
+# Background
+A bug in the pool contract code makes the fees work in reverse. We are setting them to zero to stay in a valid state, while a better solution is investigated.
+
+# Details
+
+```
+
+```
+
+# Testing
+The change has been deployed on tenderly mainnet fork []().

--- a/YPP-0048.md
+++ b/YPP-0048.md
@@ -5,10 +5,13 @@ Set pool fees to zero on all mainnet pools.
 A bug in the pool contract code makes the fees work in reverse. We are setting them to zero to stay in a valid state, while a better solution is investigated.
 
 # Details
-
 ```
-
+export const poolFees: Array<[string, number]> = [
+  [FYETH2212, 0],
+  [FYDAI2212, 0],
+  [FYUSDC2212, 0],
+]
 ```
 
 # Testing
-The change has been deployed on tenderly mainnet fork []().
+The change has been deployed on tenderly [mainnet fork](https://dashboard.tenderly.co/Yield/v2/fork/e9583153-e45d-4d42-a3c4-9fd8cf4ec2cd/simulation/11c637df-2d51-4379-8907-9e08fea1053e).


### PR DESCRIPTION
# Proposal
Set pool fees to zero on all mainnet pools.

# Background
A bug in the pool contract code makes the fees work in reverse. We are setting them to zero to stay in a valid state, while a better solution is investigated.

# Details
```
export const poolFees: Array<[string, number]> = [
  [FYETH2212, 0],
  [FYDAI2212, 0],
  [FYUSDC2212, 0],
]
```

# Testing
The change has been deployed on tenderly [mainnet fork](https://dashboard.tenderly.co/Yield/v2/fork/e9583153-e45d-4d42-a3c4-9fd8cf4ec2cd/simulation/11c637df-2d51-4379-8907-9e08fea1053e).