### PR TITLE
Add James, Raja & David as developers

### DIFF
--- a/YPP-0048.md
+++ b/YPP-0048.md
@@ -1,0 +1,17 @@
+# Proposal
+Give developer roles on mainnet to:
+- 0x9152F1f95b0819DA526BF6e0cB800559542b5b25, controlled by @Sabnock01
+- 0xa1a58E83AD7367f04501d454c7d010AB01C29d04, controlled by @calnix
+# Background
+As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
+
+# Details
+
+The (addDevelopers)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts] script will be used, with (this input)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts].
+
+```
+export const newDevelopers: string[] = [
+    '0x9152F1f95b0819DA526BF6e0cB800559542b5b25',
+    '0xa1a58E83AD7367f04501d454c7d010AB01C29d04'
+]
+```

--- a/YPP-0048.md
+++ b/YPP-0048.md
@@ -1,17 +1,23 @@
 # Proposal
+
 Give developer roles on mainnet to:
+
 - 0x9152F1f95b0819DA526BF6e0cB800559542b5b25, controlled by @Sabnock01
 - 0xa1a58E83AD7367f04501d454c7d010AB01C29d04, controlled by @calnix
+- 0x08462a2a815FE5B65D67AaC8d928C21Be2f9dDAE, controlled by @calnix
+
 # Background
+
 As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
 
 # Details
 
-The (addDevelopers)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts] script will be used, with (this input)[https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts].
+The [addDevelopers](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts).
 
 ```
 export const newDevelopers: string[] = [
     '0x9152F1f95b0819DA526BF6e0cB800559542b5b25',
-    '0xa1a58E83AD7367f04501d454c7d010AB01C29d04'
+    '0xa1a58E83AD7367f04501d454c7d010AB01C29d04',
+    '0x08462a2a815FE5B65D67AaC8d928C21Be2f9dDAE'
 ]
 ```


### PR DESCRIPTION
# Proposal

Give developer roles on mainnet to:

- `0x9152F1f95b0819DA526BF6e0cB800559542b5b25`, controlled by @Sabnock01
- `0xa1a58E83AD7367f04501d454c7d010AB01C29d04`, controlled by @calnix
- `0x08462a2a815FE5B65D67AaC8d928C21Be2f9dDAE `, controlled by @davidbrai 

# Background

As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.

# Details

The [addDevelopers](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts).

```
export const newDevelopers: string[] = [
    '0x9152F1f95b0819DA526BF6e0cB800559542b5b25',
    '0xa1a58E83AD7367f04501d454c7d010AB01C29d04',
    '0x08462a2a815FE5B65D67AaC8d928C21Be2f9dDAE'
]
```
