### PR TITLE
Deploy HealerModule and add to Ladle

### DIFF
--- a/YPP-0050.md
+++ b/YPP-0050.md
@@ -1,0 +1,37 @@
+# Proposal 
+Deploy a HealerModule to the Ladle that allows any user to add collateral or repay debt to any vault. 
+
+# Background
+To be used with the Mero Finance integration. The YieldHandler used by Mero allows for collateral top-up actions for vaults approaching liquidation. The HealerModule adds the capacity for this to be accomplished.  
+
+# Details
+The proposal includes two mainnet executions...
+1. Deploying the HealerModule using [this script](https://github.com/yieldprotocol/environments-v2/blob/7fa485f4dd0694aec6becb0f2fa1b57539b03056/scripts/governance/deploy/deployHealer.ts). The HealerModule takes the Cauldron and WETH addresses as constructor arguments. 
+2. Add the HealerModule to the Ladle using [this script](https://github.com/yieldprotocol/environments-v2/blob/7fa485f4dd0694aec6becb0f2fa1b57539b03056/scripts/governance/add/addModule/addModule.ts).
+
+
+# Testing
+The testing is done on [this test contract](https://github.com/yieldprotocol/vault-v2/blob/master/packages/foundry/contracts/test/modules/HealerModule.t.sol) which uses a mainnet fork
+
+```
+$ forge test -c contracts/test/modules/
+[⠊] Compiling...
+[⠘] Compiling 28 files with 0.8.15
+[⠒] Solc 0.8.15 finished in 1.75s
+Compiler run successful
+
+Running 3 tests for contracts/test/modules/HealerModule.t.sol:HealerModuleTest
+[PASS] testCannotAddDebt() (gas: 24595)
+Logs:
+  Cannot add to debt
+
+[PASS] testCannotRemoveCollateral() (gas: 24558)
+Logs:
+  Cannot remove collateral
+
+[PASS] testHeal() (gas: 606394)
+Logs:
+  Can add collateral and/or repay debt to a given vault
+
+Test result: ok. 3 passed; 0 failed; finished in 12.16s
+```


### PR DESCRIPTION
# Proposal 
Deploy a HealerModule to the Ladle that allows any user to add collateral or repay debt to any vault. 

# Background
To be used with the Mero Finance integration. The YieldHandler used by Mero allows for collateral top-up actions for vaults approaching liquidation. The HealerModule adds the capacity for this to be accomplished.  

# Details
The proposal includes two mainnet executions...
1. Deploying the HealerModule using [this script](https://github.com/yieldprotocol/environments-v2/blob/7fa485f4dd0694aec6becb0f2fa1b57539b03056/scripts/governance/deploy/deployHealer.ts). The HealerModule takes the Cauldron and WETH addresses as constructor arguments. 
2. Add the HealerModule to the Ladle using [this script](https://github.com/yieldprotocol/environments-v2/blob/7fa485f4dd0694aec6becb0f2fa1b57539b03056/scripts/governance/add/addModule/addModule.ts).


# Testing
The testing is done on [this test contract](https://github.com/yieldprotocol/vault-v2/blob/master/packages/foundry/contracts/test/modules/HealerModule.t.sol) which uses a mainnet fork

```
$ forge test -c contracts/test/modules/
[⠊] Compiling...
[⠘] Compiling 28 files with 0.8.15
[⠒] Solc 0.8.15 finished in 1.75s
Compiler run successful
Running 3 tests for contracts/test/modules/HealerModule.t.sol:HealerModuleTest
[PASS] testCannotAddDebt() (gas: 24595)
Logs:
  Cannot add to debt
[PASS] testCannotRemoveCollateral() (gas: 24558)
Logs:
  Cannot remove collateral
[PASS] testHeal() (gas: 606394)
Logs:
  Can add collateral and/or repay debt to a given vault
Test result: ok. 3 passed; 0 failed; finished in 12.16s
```