### PR TITLE
Sept ETH series for Arbitrum

### DIFF
--- a/YPP-0051.md
+++ b/YPP-0051.md
@@ -1,0 +1,307 @@
+# Proposal
+
+Deploy the fyToken and pool contracts for the ETH September series & activate the series
+
+# Background
+
+Following the success USDC & DAI borrowing we would enable ETH borrowing.
+
+# Details
+
+Here are the steps:
+
+1. Deploy fyToken contracts for FYETH2209 (no need for governance approval)
+2. Deploy pool contracts(no need for governance approval)
+3. Deploy strategy (no need for governance approval)
+4. Governance proposal
+   1. Add new series
+   2. Add ilks to the new series
+   3. Initialize new pools
+   4. Initialize strategy
+
+We would be deploying the fyTokens & pools using the [addEthSeriessh](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.sh), with [this input](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config.ts):
+
+```
+/// @notice Deploy fyToken series
+/// @param series identifier (bytes6 tag)
+/// @param underlying identifier (bytes6 tag)
+/// @param Address for the chi oracle
+/// @param Address for the related Join
+/// @param Maturity in unix time (seconds since Jan 1, 1970)
+/// @param Name for the series
+/// @param Symbol for the series
+export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
+  [FYETH2209, ETH, protocol.get(ACCUMULATOR) as string, joins.get(ETH) as string, EOSEP22, 'FYETH2209', 'FYETH2209'],
+]
+
+/// @notice Deploy YieldSpace pools
+/// @param pool identifier, usually matching the series (bytes6 tag)
+/// @param base address
+/// @param fyToken address
+/// @param time stretch, in 64.64
+/// @param g1, in 64.64
+/// @param g2, in 64.64
+export const poolData: Array<[string, string, string, BigNumber, BigNumber, BigNumber]> = [
+  [
+    FYETH2209,
+    assets.get(ETH) as string,
+    newFYTokens.get(FYETH2209) as string,
+    ONE64.div(secondsIn40Years),
+    ONE64.mul(75).div(100),
+    ONE64.mul(100).div(75),
+  ],
+]
+
+// Amounts to initialize pools with, a pool being identified by the related seriesId
+/// @notice Pool initialization parameters
+/// @param pool identifier, usually matching the series (bytes6 tag)
+/// @param base identifier (bytes6 tag)
+/// @param amount of base to initialize pool with
+/// @param amount of fyToken to initialize pool with
+export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [[FYETH2209, ETH, WAD.div(50), ZERO]]
+
+/// @notice Ilks to accept for series
+/// @param series identifier (bytes6 tag)
+/// @param newly accepted ilks (array of bytes6 tags)
+export const seriesIlks: Array<[string, string[]]> = [[FYETH2209, [ETH, DAI, USDC]]]
+```
+
+We would be deploying the strategies using [deployStrategies.ts](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/redeploy/deployStrategies.ts) with [this input](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config.ts)
+
+```
+/// @notice Deploy strategies
+/// @param strategy name
+/// @param strategy identifier (bytes6 tag)
+/// @param base
+/// @param Address for the related Join
+/// @param Address for the related asset
+export const strategiesData: Array<[string, string, string, string, string]> = [
+  // name, symbol, baseId
+  ['Yield Strategy ETH 6M Mar Sep', YSETH6MMS, ETH, joins.get(ETH) as string, assets.get(ETH) as string],
+]
+
+/// @notice Strategy initialization parameters
+/// @param strategy identifier (bytes6 tag)
+/// @param address of initial pool
+/// @param series identifier (bytes6 tag)
+/// @param amount of base to initialize strategy with
+export const strategiesInit: Array<[string, string, string, BigNumber]> = [
+  // [strategyId, startPoolAddress, startPoolId, initAmount]
+  [YSETH6MMS, newPools.get(FYETH2209) as string, FYETH2209, WAD.div(50)],
+]
+```
+
+# Testing
+
+The change has been deployed on a arbitrum fork with the following output.
+
+```
+++ dirname ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.sh
++ HERE=./scripts/governance/add/addSeries/addEthSeries/arbitrum
++ export CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
++ CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
++ RUN='npx hardhat run --network localhost'
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../loadTimelock.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../../../../redeploy/deployFYTokens.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+Using join at 0xaf93a04d5D8D85F69AF65ED66A9717DB0796fB10 for 0x303030370000
+Using oracle at 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848 for 0x303030370000
+FYToken deployed at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
+npx hardhat verify --network localhost 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE 0x303000000000 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848 0xaf93a04d5D8D85F69AF65ED66A9717DB0796fB10 1664550000 FYETH2209 FYETH2209 --libraries safeERC20Namer.js
+fyToken.grantRoles(ROOT, timelock)
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../../../../redeploy/deployPools.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+Using base at 0x82af49447d8a07e3bd95bd0d56f35241523fbab1
+Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
+Pool deployed at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+npx hardhat verify --network localhost 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE 14613551152 13835058055282163712 24595658764946068821 --libraries yieldMath.js
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../../../../redeploy/deployStrategies.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+Using Wrapped Ether at 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 as base
+Strategy deployed at '0xc6e7DF5E7b4f2A278906862b61205850344D4e7d'
+npx hardhat verify --network localhost 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d Yield Strategy ETH 6M Mar Sep YSETH6MMS 0x16E25cf364CeCC305590128335B8f327975d0560 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 0x303000000000 0xaf93a04d5D8D85F69AF65ED66A9717DB0796fB10 --libraries safeERC20Namer.js
+strategy.grantRoles(ROOT, timelock)
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+compoundOracle: 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
+Accumulator(00/0x524154450000): 1000000000000000000, 1000000000000000000
+Accumulator(00/0x434849000000): 1000000000000000000, 1000000000000000000
+cloak.plan(witch, join(00)): 0x6bc2a4abd3a9637c44d2b3e3ed8ad2db52aeff19dd78b6df61285b6e81612e7d
+Asset 00 made into base using 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
+Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE for 0x303030370000
+Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
+Adding 0x303030370000 for 0x303000000000 using 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
+Adding 0x303030370000 pool to Ladle using 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0007)): 0x12eeabf06a3ae55ce160a4280fdb10c130e74e52c2839479355292704c2081d7
+cloak.plan(fyToken, join(00)): 0x8362c03c1646112befa3e5f823d9e5a22668643a64782a91f849ba89ca9760ac
+Updating 0x303030370000 series with 0x303000000000,0x303100000000,0x303200000000 ilks
+addIlks 0007: 0x303000000000,0x303100000000,0x303200000000
+Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
+Timelock balance of 0x303000000000 is 80000000000000000
+Transferring 20000000000000000 of 0x303000000000 from Timelock to Pool
+Initializing FYETH2209LP at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+Transferring 0 of 0x303000000000 from Timelock to Join
+Minting 0 amount with underlying to 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+strategy(YSETH6MMS).grantRoles(gov, timelock)
+strategy(YSETH6MMS).revokeRole(ROOT, deployer)
+Timelock balance of Wrapped Ether is 80000000000000000
+Setting 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c as the next pool for YSETH6MMS
+Transferring 20000000000000000 of 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 to 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
+Starting YSETH6MMS at 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
+Burning strategy tokens
+Setting YSETH6MMS as an integration in the Ladle
+Setting YSETH6MMS as a token in the Ladle
+Proposal: 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
+Proposing
+Impersonated 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Developer: 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Proposed 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+compoundOracle: 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
+Accumulator(00/0x524154450000): 1000000000000000000, 1000000000000000000
+Accumulator(00/0x434849000000): 1000000000000000000, 1000000000000000000
+cloak.plan(witch, join(00)): 0x6bc2a4abd3a9637c44d2b3e3ed8ad2db52aeff19dd78b6df61285b6e81612e7d
+Asset 00 made into base using 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
+Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE for 0x303030370000
+Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
+Adding 0x303030370000 for 0x303000000000 using 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
+Adding 0x303030370000 pool to Ladle using 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0007)): 0x12eeabf06a3ae55ce160a4280fdb10c130e74e52c2839479355292704c2081d7
+cloak.plan(fyToken, join(00)): 0x8362c03c1646112befa3e5f823d9e5a22668643a64782a91f849ba89ca9760ac
+Updating 0x303030370000 series with 0x303000000000,0x303100000000,0x303200000000 ilks
+addIlks 0007: 0x303000000000,0x303100000000,0x303200000000
+Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
+Timelock balance of 0x303000000000 is 80000000000000000
+Transferring 20000000000000000 of 0x303000000000 from Timelock to Pool
+Initializing FYETH2209LP at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+Transferring 0 of 0x303000000000 from Timelock to Join
+Minting 0 amount with underlying to 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+strategy(YSETH6MMS).grantRoles(gov, timelock)
+strategy(YSETH6MMS).revokeRole(ROOT, deployer)
+Timelock balance of Wrapped Ether is 80000000000000000
+Setting 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c as the next pool for YSETH6MMS
+Transferring 20000000000000000 of 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 to 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
+Starting YSETH6MMS at 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
+Burning strategy tokens
+Setting YSETH6MMS as an integration in the Ladle
+Setting YSETH6MMS as a token in the Ladle
+Proposal: 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
+Approving
+Impersonated 0x7237963EED1809976A0928A42f5d6f529E0Df584
+Approved 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
+advancing time by 259200 seconds (3 days)
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.ts
+No need to generate any newer typings.
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+compoundOracle: 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
+Accumulator(00/0x524154450000): 1000000000000000000, 1000000000000000000
+Accumulator(00/0x434849000000): 1000000000000000000, 1000000000000000000
+cloak.plan(witch, join(00)): 0x6bc2a4abd3a9637c44d2b3e3ed8ad2db52aeff19dd78b6df61285b6e81612e7d
+Asset 00 made into base using 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
+Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE for 0x303030370000
+Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
+Adding 0x303030370000 for 0x303000000000 using 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
+Adding 0x303030370000 pool to Ladle using 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+join.grantRoles(join/exit, fyToken)
+fyToken.grantRoles(mint/burn, ladle)
+fyToken.grantRoles(gov, timelock)
+fyToken.revokeRole(ROOT, deployer)
+fyToken.grantRole(ROOT, cloak)
+cloak.plan(ladle, fyToken(0007)): 0x12eeabf06a3ae55ce160a4280fdb10c130e74e52c2839479355292704c2081d7
+cloak.plan(fyToken, join(00)): 0x8362c03c1646112befa3e5f823d9e5a22668643a64782a91f849ba89ca9760ac
+Updating 0x303030370000 series with 0x303000000000,0x303100000000,0x303200000000 ilks
+addIlks 0007: 0x303000000000,0x303100000000,0x303200000000
+Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
+Timelock balance of 0x303000000000 is 80000000000000000
+Transferring 20000000000000000 of 0x303000000000 from Timelock to Pool
+Initializing FYETH2209LP at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+Transferring 0 of 0x303000000000 from Timelock to Join
+Minting 0 amount with underlying to 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+strategy(YSETH6MMS).grantRoles(gov, timelock)
+strategy(YSETH6MMS).revokeRole(ROOT, deployer)
+Timelock balance of Wrapped Ether is 80000000000000000
+Setting 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c as the next pool for YSETH6MMS
+Transferring 20000000000000000 of 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 to 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
+Starting YSETH6MMS at 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
+Burning strategy tokens
+Setting YSETH6MMS as an integration in the Ladle
+Setting YSETH6MMS as a token in the Ladle
+Proposal: 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
+Executing
+Impersonated 0xC7aE076086623ecEA2450e364C838916a043F9a8
+Executed 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
+
+```
+
+The following test was run on the forked arbitrum to ensure that the protocol is working as expected:
+
+```
+++ dirname ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.sh
++ HERE=./scripts/governance/add/addSeries/addEthSeries/arbitrum
++ export CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
++ CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
++ RUN='npx hardhat run --network localhost'
++ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.test.ts
+No need to generate any newer typings.
+ChainId: 31337
+Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+Impersonated 0x489ee077994b6658eafa855c308275ead8097c4a
+series: 0x303030370000
+ilk: 0x303000000000
+vault: 0x579cb8423661c48b4613b6dd
+posting 1010000000000000000 ilk out of 43606913937197589840208
+borrowing 1000000000000000000 FYETH2209
+posted and borrowed
+repaying 1000000000000000000 FYETH2209 and withdrawing 1010000000000000000 ilk
+repaid and withdrawn
+ilk: 0x303100000000
+vault: 0x7fd36ff44a2a19bd46f133a4
+posting 2597408745825250612474 ilk out of 16035376318380364396935305
+borrowing 1000000000000000000 FYETH2209
+posted and borrowed
+repaying 1000000000000000000 FYETH2209 and withdrawing 2597408745825250612474 ilk
+repaid and withdrawn
+ilk: 0x303200000000
+vault: 0x39f3b85fd25e97f634a27c2e
+posting 2597140406 ilk out of 93719548217120
+borrowing 1000000000000000000 FYETH2209
+posted and borrowed
+repaying 10000000000
+```
+
+The g1 and g2 values being set are as follows:
+
+```
+g1 set to 13835058055282163712
+g2 set to 24595658764946068821
+```
+
+The ts value being set are as follows:
+
+```
+ts set to 14613551152
+```
+
+Maturity of the series is set to:
+
+```
+EOSEPT22 = 1664550000 // Friday, Sep 30, 2022 3:00:00 PM GMT+00:00
+```


### PR DESCRIPTION
# Proposal

Deploy the fyToken and pool contracts for the ETH September series & activate the series

# Background

Following the success USDC & DAI borrowing we would enable ETH borrowing.

# Details

Here are the steps:

1. Deploy fyToken contracts for FYETH2209 (no need for governance approval)
2. Deploy pool contracts(no need for governance approval)
3. Deploy strategy (no need for governance approval)
4. Governance proposal
   1. Add new series
   2. Add ilks to the new series
   3. Initialize new pools
   4. Initialize strategy

We would be deploying the fyTokens & pools using the [addEthSeriessh](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.sh), with [this input](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config.ts):

```
/// @notice Deploy fyToken series
/// @param series identifier (bytes6 tag)
/// @param underlying identifier (bytes6 tag)
/// @param Address for the chi oracle
/// @param Address for the related Join
/// @param Maturity in unix time (seconds since Jan 1, 1970)
/// @param Name for the series
/// @param Symbol for the series
export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
  [FYETH2209, ETH, protocol.get(ACCUMULATOR) as string, joins.get(ETH) as string, EOSEP22, 'FYETH2209', 'FYETH2209'],
]

/// @notice Deploy YieldSpace pools
/// @param pool identifier, usually matching the series (bytes6 tag)
/// @param base address
/// @param fyToken address
/// @param time stretch, in 64.64
/// @param g1, in 64.64
/// @param g2, in 64.64
export const poolData: Array<[string, string, string, BigNumber, BigNumber, BigNumber]> = [
  [
    FYETH2209,
    assets.get(ETH) as string,
    newFYTokens.get(FYETH2209) as string,
    ONE64.div(secondsIn40Years),
    ONE64.mul(75).div(100),
    ONE64.mul(100).div(75),
  ],
]

// Amounts to initialize pools with, a pool being identified by the related seriesId
/// @notice Pool initialization parameters
/// @param pool identifier, usually matching the series (bytes6 tag)
/// @param base identifier (bytes6 tag)
/// @param amount of base to initialize pool with
/// @param amount of fyToken to initialize pool with
export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [[FYETH2209, ETH, WAD.div(50), ZERO]]

/// @notice Ilks to accept for series
/// @param series identifier (bytes6 tag)
/// @param newly accepted ilks (array of bytes6 tags)
export const seriesIlks: Array<[string, string[]]> = [[FYETH2209, [ETH, DAI, USDC]]]
```

We would be deploying the strategies using [deployStrategies.ts](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/redeploy/deployStrategies.ts) with [this input](https://github.com/yieldprotocol/environments-v2/blob/0e9909a3d6c49d5ac21a19034af2620bf2012925/scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config.ts)

```
/// @notice Deploy strategies
/// @param strategy name
/// @param strategy identifier (bytes6 tag)
/// @param base
/// @param Address for the related Join
/// @param Address for the related asset
export const strategiesData: Array<[string, string, string, string, string]> = [
  // name, symbol, baseId
  ['Yield Strategy ETH 6M Mar Sep', YSETH6MMS, ETH, joins.get(ETH) as string, assets.get(ETH) as string],
]

/// @notice Strategy initialization parameters
/// @param strategy identifier (bytes6 tag)
/// @param address of initial pool
/// @param series identifier (bytes6 tag)
/// @param amount of base to initialize strategy with
export const strategiesInit: Array<[string, string, string, BigNumber]> = [
  // [strategyId, startPoolAddress, startPoolId, initAmount]
  [YSETH6MMS, newPools.get(FYETH2209) as string, FYETH2209, WAD.div(50)],
]
```

# Testing

The change has been deployed on a arbitrum fork with the following output.

```
++ dirname ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.sh
+ HERE=./scripts/governance/add/addSeries/addEthSeries/arbitrum
+ export CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
+ CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
+ RUN='npx hardhat run --network localhost'
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../loadTimelock.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../../../../redeploy/deployFYTokens.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
Using join at 0xaf93a04d5D8D85F69AF65ED66A9717DB0796fB10 for 0x303030370000
Using oracle at 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848 for 0x303030370000
FYToken deployed at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
npx hardhat verify --network localhost 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE 0x303000000000 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848 0xaf93a04d5D8D85F69AF65ED66A9717DB0796fB10 1664550000 FYETH2209 FYETH2209 --libraries safeERC20Namer.js
fyToken.grantRoles(ROOT, timelock)
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../../../../redeploy/deployPools.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
Using base at 0x82af49447d8a07e3bd95bd0d56f35241523fbab1
Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
Pool deployed at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
npx hardhat verify --network localhost 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE 14613551152 13835058055282163712 24595658764946068821 --libraries yieldMath.js
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/../../../../redeploy/deployStrategies.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
Using Wrapped Ether at 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 as base
Strategy deployed at '0xc6e7DF5E7b4f2A278906862b61205850344D4e7d'
npx hardhat verify --network localhost 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d Yield Strategy ETH 6M Mar Sep YSETH6MMS 0x16E25cf364CeCC305590128335B8f327975d0560 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 0x303000000000 0xaf93a04d5D8D85F69AF65ED66A9717DB0796fB10 --libraries safeERC20Namer.js
strategy.grantRoles(ROOT, timelock)
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
compoundOracle: 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
Accumulator(00/0x524154450000): 1000000000000000000, 1000000000000000000
Accumulator(00/0x434849000000): 1000000000000000000, 1000000000000000000
cloak.plan(witch, join(00)): 0x6bc2a4abd3a9637c44d2b3e3ed8ad2db52aeff19dd78b6df61285b6e81612e7d
Asset 00 made into base using 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE for 0x303030370000
Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
Adding 0x303030370000 for 0x303000000000 using 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
Adding 0x303030370000 pool to Ladle using 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0007)): 0x12eeabf06a3ae55ce160a4280fdb10c130e74e52c2839479355292704c2081d7
cloak.plan(fyToken, join(00)): 0x8362c03c1646112befa3e5f823d9e5a22668643a64782a91f849ba89ca9760ac
Updating 0x303030370000 series with 0x303000000000,0x303100000000,0x303200000000 ilks
addIlks 0007: 0x303000000000,0x303100000000,0x303200000000
Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
Timelock balance of 0x303000000000 is 80000000000000000
Transferring 20000000000000000 of 0x303000000000 from Timelock to Pool
Initializing FYETH2209LP at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
Transferring 0 of 0x303000000000 from Timelock to Join
Minting 0 amount with underlying to 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
strategy(YSETH6MMS).grantRoles(gov, timelock)
strategy(YSETH6MMS).revokeRole(ROOT, deployer)
Timelock balance of Wrapped Ether is 80000000000000000
Setting 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c as the next pool for YSETH6MMS
Transferring 20000000000000000 of 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 to 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
Starting YSETH6MMS at 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
Burning strategy tokens
Setting YSETH6MMS as an integration in the Ladle
Setting YSETH6MMS as a token in the Ladle
Proposal: 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
Proposing
Impersonated 0xC7aE076086623ecEA2450e364C838916a043F9a8
Developer: 0xC7aE076086623ecEA2450e364C838916a043F9a8
Proposed 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
compoundOracle: 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
Accumulator(00/0x524154450000): 1000000000000000000, 1000000000000000000
Accumulator(00/0x434849000000): 1000000000000000000, 1000000000000000000
cloak.plan(witch, join(00)): 0x6bc2a4abd3a9637c44d2b3e3ed8ad2db52aeff19dd78b6df61285b6e81612e7d
Asset 00 made into base using 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE for 0x303030370000
Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
Adding 0x303030370000 for 0x303000000000 using 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
Adding 0x303030370000 pool to Ladle using 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0007)): 0x12eeabf06a3ae55ce160a4280fdb10c130e74e52c2839479355292704c2081d7
cloak.plan(fyToken, join(00)): 0x8362c03c1646112befa3e5f823d9e5a22668643a64782a91f849ba89ca9760ac
Updating 0x303030370000 series with 0x303000000000,0x303100000000,0x303200000000 ilks
addIlks 0007: 0x303000000000,0x303100000000,0x303200000000
Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
Timelock balance of 0x303000000000 is 80000000000000000
Transferring 20000000000000000 of 0x303000000000 from Timelock to Pool
Initializing FYETH2209LP at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
Transferring 0 of 0x303000000000 from Timelock to Join
Minting 0 amount with underlying to 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
strategy(YSETH6MMS).grantRoles(gov, timelock)
strategy(YSETH6MMS).revokeRole(ROOT, deployer)
Timelock balance of Wrapped Ether is 80000000000000000
Setting 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c as the next pool for YSETH6MMS
Transferring 20000000000000000 of 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 to 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
Starting YSETH6MMS at 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
Burning strategy tokens
Setting YSETH6MMS as an integration in the Ladle
Setting YSETH6MMS as a token in the Ladle
Proposal: 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
Approving
Impersonated 0x7237963EED1809976A0928A42f5d6f529E0Df584
Approved 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
advancing time by 259200 seconds (3 days)
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.ts
No need to generate any newer typings.
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
compoundOracle: 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
Accumulator(00/0x524154450000): 1000000000000000000, 1000000000000000000
Accumulator(00/0x434849000000): 1000000000000000000, 1000000000000000000
cloak.plan(witch, join(00)): 0x6bc2a4abd3a9637c44d2b3e3ed8ad2db52aeff19dd78b6df61285b6e81612e7d
Asset 00 made into base using 0x0ad9Ef93673B6081c0c3b753CcaaBDdd8d2e7848
Using fyToken at 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE for 0x303030370000
Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
Adding 0x303030370000 for 0x303000000000 using 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE
Adding 0x303030370000 pool to Ladle using 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
join.grantRoles(join/exit, fyToken)
fyToken.grantRoles(mint/burn, ladle)
fyToken.grantRoles(gov, timelock)
fyToken.revokeRole(ROOT, deployer)
fyToken.grantRole(ROOT, cloak)
cloak.plan(ladle, fyToken(0007)): 0x12eeabf06a3ae55ce160a4280fdb10c130e74e52c2839479355292704c2081d7
cloak.plan(fyToken, join(00)): 0x8362c03c1646112befa3e5f823d9e5a22668643a64782a91f849ba89ca9760ac
Updating 0x303030370000 series with 0x303000000000,0x303100000000,0x303200000000 ilks
addIlks 0007: 0x303000000000,0x303100000000,0x303200000000
Using pool at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c for 0x303030370000
Timelock balance of 0x303000000000 is 80000000000000000
Transferring 20000000000000000 of 0x303000000000 from Timelock to Pool
Initializing FYETH2209LP at 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
Transferring 0 of 0x303000000000 from Timelock to Join
Minting 0 amount with underlying to 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
strategy(YSETH6MMS).grantRoles(gov, timelock)
strategy(YSETH6MMS).revokeRole(ROOT, deployer)
Timelock balance of Wrapped Ether is 80000000000000000
Setting 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c as the next pool for YSETH6MMS
Transferring 20000000000000000 of 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 to 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
Starting YSETH6MMS at 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d
Burning strategy tokens
Setting YSETH6MMS as an integration in the Ladle
Setting YSETH6MMS as a token in the Ladle
Proposal: 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49
Executing
Impersonated 0xC7aE076086623ecEA2450e364C838916a043F9a8
Executed 0x09af7c12e664c93f4967150bbf1bda0acccf6eb0d0ed5cea431b652390b62b49

```

The following test was run on the forked arbitrum to ensure that the protocol is working as expected:

```
++ dirname ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.sh
+ HERE=./scripts/governance/add/addSeries/addEthSeries/arbitrum
+ export CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
+ CONF=/Users/praffulsahu/Documents/Crypto/Yield/environments-v2/./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.arb_mainnet.config
+ RUN='npx hardhat run --network localhost'
+ npx hardhat run --network localhost ./scripts/governance/add/addSeries/addEthSeries/arbitrum/addEthSeries.test.ts
No need to generate any newer typings.
ChainId: 31337
Impersonating 0xC7aE076086623ecEA2450e364C838916a043F9a8 on localhost
Impersonated 0x489ee077994b6658eafa855c308275ead8097c4a
series: 0x303030370000
ilk: 0x303000000000
vault: 0x579cb8423661c48b4613b6dd
posting 1010000000000000000 ilk out of 43606913937197589840208
borrowing 1000000000000000000 FYETH2209
posted and borrowed
repaying 1000000000000000000 FYETH2209 and withdrawing 1010000000000000000 ilk
repaid and withdrawn
ilk: 0x303100000000
vault: 0x7fd36ff44a2a19bd46f133a4
posting 2597408745825250612474 ilk out of 16035376318380364396935305
borrowing 1000000000000000000 FYETH2209
posted and borrowed
repaying 1000000000000000000 FYETH2209 and withdrawing 2597408745825250612474 ilk
repaid and withdrawn
ilk: 0x303200000000
vault: 0x39f3b85fd25e97f634a27c2e
posting 2597140406 ilk out of 93719548217120
borrowing 1000000000000000000 FYETH2209
posted and borrowed
repaying 10000000000
```

The g1 and g2 values being set are as follows:

```
g1 set to 13835058055282163712
g2 set to 24595658764946068821
```

The ts value being set are as follows:

```
ts set to 14613551152
```

Maturity of the series is set to:

```
EOSEPT22 = 1664550000 // Friday, Sep 30, 2022 3:00:00 PM GMT+00:00
```
