### PR TITLE
WrapEthModule on Arbitrum

### DIFF
--- a/YPP-0052.md
+++ b/YPP-0052.md
@@ -1,0 +1,16 @@
+# Proposal
+
+Deploy the wrapEtherModule to automate wrapping of `AETH` to `WETH`.
+
+# Background
+
+The Sept ETH series accepts `WETH` & not `AETH`. So the users would have to wrap `AETH`.
+
+# Details
+
+1. Deploy WrapEtherModule (no need for governance approval)
+2. Add the module to ladle
+
+# Testing
+
+The module was tested on a tenderly fork: https://dashboard.tenderly.co/Yield/v2-arbitrum/fork/2c68a094-0507-462e-ba1c-ee0e6d096717


### PR DESCRIPTION
# Proposal

Deploy the wrapEtherModule to automate wrapping of `AETH` to `WETH`.

# Background

The Sept ETH series accepts `WETH` & not `AETH`. So the users would have to wrap `AETH`.

# Details

1. Deploy WrapEtherModule (no need for governance approval)
2. Add the module to ladle

# Testing

The module was tested on a tenderly fork: https://dashboard.tenderly.co/Yield/v2-arbitrum/fork/2c68a094-0507-462e-ba1c-ee0e6d096717
