### PR TITLE
Deploy & configure contracts needed by Contango

### DIFF
--- a/YPP-0053.md
+++ b/YPP-0053.md
@@ -1,0 +1,30 @@
+# Proposal
+
+Deploy & configure contracts needed by Contango. 
+
+# Background
+
+Contango exchange uses fixed rate markets to synthesise expirable futures.
+In order to allow for a smoother interaction, Yield will deploy a set of contracts specially tailored for Contango.
+This is the first proposal (out of 3) that'll allow for the full integration with Contango.
+
+# Details
+
+Here are the steps:
+
+1. Deploy a separate Cauldron (no need for governance approval)
+2. Deploy a specialised Ladle (no need for governance approval)
+3. Deploy the composite oracle (no need for governance approval)
+4. Deploy the identity oracle (no need for governance approval)
+5. Governance proposal
+   1. Configure Cauldron permissions
+   2. Configure Ladle permissions
+   3. Configure CompositeOracle permissions
+
+The contracts have been deployed to Arbitrum mainnet and the proposal sent to the multisig.
+
+# Testing
+
+The proposal approval & execution were tested on tenderly: https://rpc.tenderly.co/fork/6c0b2c81-4246-40f8-9809-0c87655ef12f
+
+

--- a/YPP-0053.md
+++ b/YPP-0053.md
@@ -21,10 +21,12 @@ Here are the steps:
    2. Configure Ladle permissions
    3. Configure CompositeOracle permissions
 
+Script that performed said actions: https://github.com/yieldprotocol/environments-v2/blob/9ce65d72eece5de5fb002432175455185eb0545d/scripts/governance/contango/arbitrum/deployContango.sh
+
 The contracts have been deployed to Arbitrum mainnet and the proposal sent to the multisig.
 
 # Testing
 
-The proposal approval & execution were tested on tenderly: https://rpc.tenderly.co/fork/6c0b2c81-4246-40f8-9809-0c87655ef12f
+The proposal approval & execution were tested on tenderly: https://dashboard.tenderly.co/Yield/v2-arbitrum/fork/6c0b2c81-4246-40f8-9809-0c87655ef12f
 
 


### PR DESCRIPTION
# Proposal

Deploy & configure contracts needed by Contango. 

# Background

Contango exchange uses fixed rate markets to synthesise expirable futures.
In order to allow for a smoother interaction, Yield will deploy a set of contracts specially tailored for Contango.
This is the first proposal (out of 3) that'll allow for the full integration with Contango.

# Details

Here are the steps:

1. Deploy a separate Cauldron (no need for governance approval)
2. Deploy a specialised Ladle (no need for governance approval)
3. Deploy the composite oracle (no need for governance approval)
4. Deploy the identity oracle (no need for governance approval)
5. Governance proposal
   1. Configure Cauldron permissions
   2. Configure Ladle permissions
   3. Configure CompositeOracle permissions

Script that performed said actions: https://github.com/yieldprotocol/environments-v2/blob/9ce65d72eece5de5fb002432175455185eb0545d/scripts/governance/contango/arbitrum/deployContango.sh

The contracts have been deployed to Arbitrum mainnet and the proposal sent to the multisig.

# Testing

The proposal approval & execution were tested on tenderly: https://dashboard.tenderly.co/Yield/v2-arbitrum/fork/6c0b2c81-4246-40f8-9809-0c87655ef12f

