### PR TITLE
Restore December FRAX on mainnet

### DIFF
--- a/YPP-0058.md
+++ b/YPP-0058.md
@@ -139,3 +139,15 @@ export const strategiesInit: Array<[string, string, string, BigNumber]> = [
 # Testing
 
 TBA
+
+# Proposal
+NonTvPools (frax) merged to mainnet and proposal submitted.
+[New pool](https://etherscan.io/address/0xFa38F3717daD95085FF725aA93608Af3fa1D9e58)
+[New Strategy](https://etherscan.io/address/0xbD6277E36686184A5343F83a4be5CeD0f8CD185A)
+Here are [the logs](https://github.com/yieldprotocol/environments-v2/blob/mainnetAddNonTv/addresses/mainnet/16-sep-2022-output.txt)
+Proposal txn hash: 0x30d4eb87641904ae771529241c80923454b02da2e316c99e09c8d8a034d7ffa3
+
+[Fork events reviewed](https://dashboard.tenderly.co/Yield/v2/fork/b96b75d9-6da2-4c65-87c3-349e5f3bbe4a/simulation/fb34c061-9342-4087-980f-077a76d9082c/logs)
+
+# Execution
+https://etherscan.io/tx/0xf2d8122c77b508457e3fe881875a404703001ff4b00f0b276589872662355d24

--- a/YPP-0058.md
+++ b/YPP-0058.md
@@ -1,0 +1,141 @@
+# Proposal
+
+Restore FRAX December pool, and associated strategy, on Mainnet
+
+# Background
+
+The June to December roll included the activation of the new YieldSpace-tv pools, and the NonTV implementation used by the FRAX series contained a critical bug. The pool was drained by the team. The associated strategy cannot be modified until maturity, but can be replaced by a new one. With this proposal we are bringing everything back. In addition, YieldMath.sol is being redeployed.
+
+# Details
+
+The summary of the execution is as follows:
+
+1. Deploy YieldMath.sol (no need for governance approval)
+2. Deploy the FYFRAX2212 pool (no need for governance approval)
+3. Deploy YSFRAX6MJD strategy (no need for governance approval)
+4. Governance proposal
+   a. Orchestrate the new pool
+   b. Register the new pool in the Ladle
+   c. Initialize the new pool
+   d. Orchestrate the new strategy
+   e. Initialize the new strategy
+
+These steps are encoded [here](https://github.com/yieldprotocol/environments-v2/tree/main/scripts/governance/add/addSeries/addNonTvSeries) (access restricted).
+
+[This input](https://github.com/yieldprotocol/environments-v2/blob/8cbc62a1418405da28c007907be3f1994ea00195/scripts/governance/add/addSeries/addNonTvSeries/addNonTvSeries.mainnet.config.ts) will be used:
+
+## Proposal Config
+
+```
+import { BigNumber } from 'ethers'
+import {
+  ZERO,
+  ZERO_ADDRESS,
+  WAD,
+  ONEUSDC,
+  MAX256,
+  ONE64,
+  secondsIn25Years,
+  secondsInOneYear,
+} from '../../../../../shared/constants'
+import {
+  ETH,
+  DAI,
+  USDC,
+  WBTC,
+  WSTETH,
+  LINK,
+  ENS,
+  UNI,
+  FRAX,
+  YVDAI,
+  YVUSDC,
+  EWETH,
+  EDAI,
+  EUSDC,
+} from '../../../../../shared/constants'
+import { EODEC22 } from '../../../../../shared/constants'
+import { FYETH2212, FYDAI2212, FYUSDC2212, FYFRAX2212 } from '../../../../../shared/constants'
+import { YSETH6MJD, YSDAI6MJD, YSUSDC6MJD, YSFRAX6MJD } from '../../../../../shared/constants'
+import { COMPOUND, ACCUMULATOR } from '../../../../../shared/constants'
+
+import * as base_config from '../../../base.mainnet.config'
+
+export const chainId: number = base_config.chainId
+export const developer: string = '0xC7aE076086623ecEA2450e364C838916a043F9a8'
+export const deployer: string = '0xfe90d993367bc93D171A5ED88ab460759DE2bED6'
+export const whales: Map<string, string> = base_config.whales
+
+export const governance: Map<string, string> = base_config.governance
+export const protocol: Map<string, string> = base_config.protocol
+export const assets: Map<string, string> = base_config.assets
+export const joins: Map<string, string> = base_config.joins
+export const strategies: Map<string, string> = base_config.strategies
+export const fyTokens: Map<string, string> = base_config.fyTokens
+export const newJoins: Map<string, string> = base_config.newJoins
+export const newPools: Map<string, string> = base_config.newPools
+export const newStrategies: Map<string, string> = base_config.newStrategies
+export const eulerAddress = base_config.eulerAddress
+export const flashMintModule = '0x1EB4CF3A948E7D72A198fe073cCb8C7a948cD853'
+
+// Time stretch to be set in the PoolFactory prior to pool deployment
+export const timeStretch: Map<string, BigNumber> = new Map([[FYFRAX2212, ONE64.div(secondsInOneYear.mul(20))]])
+
+// Sell base to the pool fee, as fp4
+export const g1: number = 9000
+
+// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
+export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
+  [
+    FYFRAX2212,
+    FRAX,
+    protocol.get(ACCUMULATOR) as string,
+    joins.get(FRAX) as string,
+    EODEC22,
+    'FYFRAX2212',
+    'FYFRAX2212',
+  ],
+]
+
+// Parameters to deploy pools with, a pool being identified by the related seriesId
+// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee)
+export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
+  [
+    FYFRAX2212,
+    assets.get(FRAX) as string,
+    fyTokens.get(FYFRAX2212) as string,
+    timeStretch.get(FYFRAX2212) as BigNumber,
+    g1,
+  ],
+]
+
+// Amounts to initialize pools with, a pool being identified by the related seriesId
+// seriesId, initAmount
+export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
+  [FYFRAX2212, FRAX, WAD.mul(100), BigNumber.from('0')],
+]
+
+// // Ilks to accept for each series
+// // seriesId, accepted ilks
+// export const seriesIlks: Array<[string, string[]]> = [
+//   [FYETH2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX]],
+//   [FYDAI2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX]],
+//   [FYUSDC2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX, YVUSDC]],
+//   [FYFRAX2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX]],
+// ]
+
+export const strategiesData: Array<[string, string, string]> = [
+  // name, symbol, baseId
+  ['Yield Strategy FRAX 6M Jun Dec', YSFRAX6MJD, FRAX],
+]
+
+// Input data
+export const strategiesInit: Array<[string, string, string, BigNumber]> = [
+  // [strategyId, startPoolAddress, startPoolId, initAmount]
+  [YSFRAX6MJD, newPools.get(FYFRAX2212) as string, FYFRAX2212, WAD.mul(100)],
+]
+```
+
+# Testing
+
+TBA


### PR DESCRIPTION
# Proposal

Restore FRAX December pool, and associated strategy, on Mainnet

# Background

The June to December roll included the activation of the new YieldSpace-tv pools, and the NonTV implementation used by the FRAX series contained a critical bug. The pool was drained by the team. The associated strategy cannot be modified until maturity, but can be replaced by a new one. With this proposal we are bringing everything back. In addition, YieldMath.sol is being redeployed.

# Details

The summary of the execution is as follows:

1. Deploy YieldMath.sol (no need for governance approval)
2. Deploy the FYFRAX2212 pool (no need for governance approval)
3. Deploy YSFRAX6MJD strategy (no need for governance approval)
4. Governance proposal
   a. Orchestrate the new pool
   b. Register the new pool in the Ladle
   c. Initialize the new pool
   d. Orchestrate the new strategy
   e. Initialize the new strategy

These steps are encoded [here](https://github.com/yieldprotocol/environments-v2/tree/main/scripts/governance/add/addSeries/addNonTvSeries) (access restricted).

[This input](https://github.com/yieldprotocol/environments-v2/blob/8cbc62a1418405da28c007907be3f1994ea00195/scripts/governance/add/addSeries/addNonTvSeries/addNonTvSeries.mainnet.config.ts) will be used:

## Proposal Config

```
import { BigNumber } from 'ethers'
import {
  ZERO,
  ZERO_ADDRESS,
  WAD,
  ONEUSDC,
  MAX256,
  ONE64,
  secondsIn25Years,
  secondsInOneYear,
} from '../../../../../shared/constants'
import {
  ETH,
  DAI,
  USDC,
  WBTC,
  WSTETH,
  LINK,
  ENS,
  UNI,
  FRAX,
  YVDAI,
  YVUSDC,
  EWETH,
  EDAI,
  EUSDC,
} from '../../../../../shared/constants'
import { EODEC22 } from '../../../../../shared/constants'
import { FYETH2212, FYDAI2212, FYUSDC2212, FYFRAX2212 } from '../../../../../shared/constants'
import { YSETH6MJD, YSDAI6MJD, YSUSDC6MJD, YSFRAX6MJD } from '../../../../../shared/constants'
import { COMPOUND, ACCUMULATOR } from '../../../../../shared/constants'

import * as base_config from '../../../base.mainnet.config'

export const chainId: number = base_config.chainId
export const developer: string = '0xC7aE076086623ecEA2450e364C838916a043F9a8'
export const deployer: string = '0xfe90d993367bc93D171A5ED88ab460759DE2bED6'
export const whales: Map<string, string> = base_config.whales

export const governance: Map<string, string> = base_config.governance
export const protocol: Map<string, string> = base_config.protocol
export const assets: Map<string, string> = base_config.assets
export const joins: Map<string, string> = base_config.joins
export const strategies: Map<string, string> = base_config.strategies
export const fyTokens: Map<string, string> = base_config.fyTokens
export const newJoins: Map<string, string> = base_config.newJoins
export const newPools: Map<string, string> = base_config.newPools
export const newStrategies: Map<string, string> = base_config.newStrategies
export const eulerAddress = base_config.eulerAddress
export const flashMintModule = '0x1EB4CF3A948E7D72A198fe073cCb8C7a948cD853'

// Time stretch to be set in the PoolFactory prior to pool deployment
export const timeStretch: Map<string, BigNumber> = new Map([[FYFRAX2212, ONE64.div(secondsInOneYear.mul(20))]])

// Sell base to the pool fee, as fp4
export const g1: number = 9000

// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
  [
    FYFRAX2212,
    FRAX,
    protocol.get(ACCUMULATOR) as string,
    joins.get(FRAX) as string,
    EODEC22,
    'FYFRAX2212',
    'FYFRAX2212',
  ],
]

// Parameters to deploy pools with, a pool being identified by the related seriesId
// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee)
export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
  [
    FYFRAX2212,
    assets.get(FRAX) as string,
    fyTokens.get(FYFRAX2212) as string,
    timeStretch.get(FYFRAX2212) as BigNumber,
    g1,
  ],
]

// Amounts to initialize pools with, a pool being identified by the related seriesId
// seriesId, initAmount
export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
  [FYFRAX2212, FRAX, WAD.mul(100), BigNumber.from('0')],
]

// // Ilks to accept for each series
// // seriesId, accepted ilks
// export const seriesIlks: Array<[string, string[]]> = [
//   [FYETH2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX]],
//   [FYDAI2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX]],
//   [FYUSDC2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX, YVUSDC]],
//   [FYFRAX2212, [ETH, DAI, USDC, WBTC, WSTETH, LINK, ENS, UNI, FRAX]],
// ]

export const strategiesData: Array<[string, string, string]> = [
  // name, symbol, baseId
  ['Yield Strategy FRAX 6M Jun Dec', YSFRAX6MJD, FRAX],
]

// Input data
export const strategiesInit: Array<[string, string, string, BigNumber]> = [
  // [strategyId, startPoolAddress, startPoolId, initAmount]
  [YSFRAX6MJD, newPools.get(FYFRAX2212) as string, FYFRAX2212, WAD.mul(100)],
]
```

# Testing

TBA