### PR TITLE
Add Bruno from Contango as a dev on Arbitrum

### DIFF
--- a/YPP-0062.md
+++ b/YPP-0062.md
@@ -1,0 +1,20 @@
+# Proposal
+
+Give developer roles on arbitrum to:
+
+- 0x05950b4e68f103d5aBEf20364dE219a247e59C23, controlled by @bbbonnano
+
+# Background
+
+As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
+
+# Details
+
+The [addDevelopers](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts).
+
+```
+export const newDevelopers: string[] = [
+  '0x05950b4e68f103d5aBEf20364dE219a247e59C23', // Bruno
+]
+
+```


### PR DESCRIPTION
# Proposal

Give developer roles on arbitrum to:

- 0x05950b4e68f103d5aBEf20364dE219a247e59C23, controlled by @bbbonnano

# Background

As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.

# Details

The [addDevelopers](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts).

```
export const newDevelopers: string[] = [
  '0x05950b4e68f103d5aBEf20364dE219a247e59C23', // Bruno
]
```