### PR TITLE
Add marco as a dev

### DIFF
--- a/YPP-0064.md
+++ b/YPP-0064.md
@@ -1,0 +1,20 @@
+# Proposal
+
+Give developer roles on arbitrum to:
+
+- 0x1662BbbDdA3fb169f10C495AE27596Af7f8fD3E1, controlled by @marcomariscal
+
+# Background
+
+As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.
+
+# Details
+
+The [addDevelopers](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts).
+
+```
+export const newDevelopers: string[] = [
+  '0x1662BbbDdA3fb169f10C495AE27596Af7f8fD3E1', // Marco
+]
+
+```


### PR DESCRIPTION
# Proposal

Give developer roles on arbitrum to:

- 0x1662BbbDdA3fb169f10C495AE27596Af7f8fD3E1, controlled by @marcomariscal

# Background

As the team grows we need to let other developers propose new features, so adding new authorized developers. Developers can propose and execute governance proposals, but not approve them. Developers can also execute emergency plans, but not register them or restore permissions.

# Details

The [addDevelopers](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.ts) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/main/scripts/governance/permissions/addDevelopers/addDevelopers.config.ts).

```
export const newDevelopers: string[] = [
  '0x1662BbbDdA3fb169f10C495AE27596Af7f8fD3E1', // Marco
]
```