### PR TITLE
YP-67: Roll Mar 23-Arbitrum

### DIFF
--- a/YPP-0067.md
+++ b/YPP-0067.md
@@ -1,0 +1,97 @@
+# Proposal
+Activate the DAI, USDC, and ETH March series on Arbitrum mainnet using yieldspace-tv, and roll the respective strategies (YSETH6MMS, YSDAI6MMS, YSUSDC6MMS) from September to March.
+
+# Background 
+On September 22nd 2022 all September series matured, and the strategies stopped accruing fees. New yieldspace-tv pools are going to be used for the March series.
+
+# Details
+The steps are: 
+    1. Deploy new fyTokens and Non-tv pools.
+    2. Activate the March series
+    3. Governance proposal
+          i. Orchestrate pools
+         ii. Add new series
+        iii. Add ilks to the new series
+         iv. Initialize new pools
+          v. Roll the strategies to the next pool
+
+```
+// Time stretch to be set in the PoolFactory prior to pool deployment
+export const timeStretch: Map<string, BigNumber> = new Map([
+  [FYETH2303, ONE64.div(secondsInOneYear.mul(25))],
+  [FYDAI2303, ONE64.div(secondsInOneYear.mul(45))],
+  [FYUSDC2303, ONE64.div(secondsInOneYear.mul(55))],
+])
+
+// Sell base to the pool fee, as fp4
+export const g1: number = 9000
+
+// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
+export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
+  [FYETH2303, ETH, protocol.get(ACCUMULATOR) as string, joins.get(ETH) as string, EOMAR23, 'FYETH2303', 'FYETH2303'],
+  [FYDAI2303, DAI, protocol.get(ACCUMULATOR) as string, joins.get(DAI) as string, EOMAR23, 'FYDAI2303', 'FYDAI2303'],
+  [
+    FYUSDC2303,
+    USDC,
+    protocol.get(ACCUMULATOR) as string,
+    joins.get(USDC) as string,
+    EOMAR23,
+    'FYUSDC2303',
+    'FYUSDC2303',
+  ],
+]
+
+// Parameters to deploy pools with, a pool being identified by the related seriesId
+// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee)
+export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
+  [
+    FYETH2303,
+    assets.get(ETH) as string,
+    newFYTokens.get(FYETH2303) as string,
+    timeStretch.get(FYETH2303) as BigNumber,
+    g1,
+  ],
+  [
+    FYDAI2303,
+    assets.get(DAI) as string,
+    newFYTokens.get(FYDAI2303) as string,
+    timeStretch.get(FYDAI2303) as BigNumber,
+    g1,
+  ],
+  [
+    FYUSDC2303,
+    assets.get(USDC) as string,
+    newFYTokens.get(FYUSDC2303) as string,
+    timeStretch.get(FYUSDC2303) as BigNumber,
+    g1,
+  ],
+]
+
+// Amounts to initialize pools with, a pool being identified by the related seriesId
+// seriesId, initAmount
+export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
+  [FYETH2303, DAI, WAD.div(10), BigNumber.from('0')],
+  [FYDAI2303, DAI, WAD.mul(100), BigNumber.from('0')],
+  [FYUSDC2303, USDC, ONEUSDC.mul(100), BigNumber.from('0')],
+]
+
+// Ilks to accept for each series
+// seriesId, accepted ilks
+export const seriesIlks: Array<[string, string[]]> = [
+  [FYETH2303, [ETH, DAI, USDC]],
+  [FYDAI2303, [ETH, DAI, USDC]],
+  [FYUSDC2303, [ETH, DAI, USDC]],
+]
+
+/// Parameters to roll each strategy
+/// @param strategyId
+/// @param nextSeriesId
+/// @param buffer Amount of base sent to the Roller to make up for market losses when using a flash loan for rolling
+/// @param lender ERC3156 flash lender used for rolling
+/// @param fix If true, transfer one base wei to the pool to allow the Strategy to start enhanced TV pools
+export const rollData: Array<[string, string, BigNumber, string, boolean]> = [
+  [YSETH6MMS, FYETH2303, ZERO, ZERO_ADDRESS, false],
+  [YSDAI6MMS, FYDAI2303, ZERO, ZERO_ADDRESS, false],
+  [YSUSDC6MMS, FYUSDC2303, ZERO, ZERO_ADDRESS, false],
+]
+```

--- a/YPP-0067.md
+++ b/YPP-0067.md
@@ -16,17 +16,26 @@ The steps are:
           v. Roll the strategies to the next pool
 
 ```
-// Time stretch to be set in the PoolFactory prior to pool deployment
+/// @notice Time stretch to be set in the PoolFactory prior to pool deployment
+/// @param series identifier (bytes6 tag)
+/// @param time stretch (64.64)
 export const timeStretch: Map<string, BigNumber> = new Map([
   [FYETH2303, ONE64.div(secondsInOneYear.mul(25))],
   [FYDAI2303, ONE64.div(secondsInOneYear.mul(45))],
   [FYUSDC2303, ONE64.div(secondsInOneYear.mul(55))],
 ])
 
-// Sell base to the pool fee, as fp4
+/// @notice Sell base to the pool fee, as fp4
 export const g1: number = 9000
 
-// seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol
+/// @notice Deploy fyToken series
+/// @param series identifier (bytes6 tag)
+/// @param underlying identifier (bytes6 tag)
+/// @param Address for the chi oracle
+/// @param Address for the related Join
+/// @param Maturity in unix time (seconds since Jan 1, 1970)
+/// @param Name for the series
+/// @param Symbol for the series
 export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
   [FYETH2303, ETH, protocol.get(ACCUMULATOR) as string, joins.get(ETH) as string, EOMAR23, 'FYETH2303', 'FYETH2303'],
   [FYDAI2303, DAI, protocol.get(ACCUMULATOR) as string, joins.get(DAI) as string, EOMAR23, 'FYDAI2303', 'FYDAI2303'],
@@ -41,8 +50,12 @@ export const fyTokenData: Array<[string, string, string, string, number, string,
   ],
 ]
 
-// Parameters to deploy pools with, a pool being identified by the related seriesId
-// seriesId, baseAddress, fyTokenAddress, ts (time stretch), g1 (Sell base to the pool fee)
+/// @notice Deploy plain YieldSpace pools
+/// @param pool identifier, usually matching the series (bytes6 tag)
+/// @param base address
+/// @param fyToken address
+/// @param time stretch, in 64.64
+/// @param g1, in 64.64
 export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
   [
     FYETH2303,
@@ -67,16 +80,18 @@ export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> =
   ],
 ]
 
-// Amounts to initialize pools with, a pool being identified by the related seriesId
-// seriesId, initAmount
-export const poolsInit: Array<[string, string, BigNumber, BigNumber]> = [
-  [FYETH2303, DAI, WAD.div(10), BigNumber.from('0')],
-  [FYDAI2303, DAI, WAD.mul(100), BigNumber.from('0')],
-  [FYUSDC2303, USDC, ONEUSDC.mul(100), BigNumber.from('0')],
+/// @notice Pool initialization parameters
+/// @param pool identifier, usually matching the series (bytes6 tag)
+/// @param amount of base to initialize pool with
+export const poolsInit: Array<[string, BigNumber]> = [
+  [FYETH2303, WAD.div(10)],
+  [FYDAI2303, WAD.mul(100)],
+  [FYUSDC2303, ONEUSDC.mul(100)],
 ]
 
-// Ilks to accept for each series
-// seriesId, accepted ilks
+/// @notice Ilks to accept for series
+/// @param series identifier (bytes6 tag)
+/// @param newly accepted ilks (array of bytes6 tags)
 export const seriesIlks: Array<[string, string[]]> = [
   [FYETH2303, [ETH, DAI, USDC]],
   [FYDAI2303, [ETH, DAI, USDC]],


### PR DESCRIPTION
# Proposal
Activate the DAI, USDC, and ETH March series on Arbitrum mainnet using yieldspace-tv, and roll the respective strategies (YSETH6MMS, YSDAI6MMS, YSUSDC6MMS) from September to March.

# Background 
On September 22nd 2022 all September series matured, and the strategies stopped accruing fees. New yieldspace-tv pools are going to be used for the March series.

# Details
The steps are: 
    1. Deploy new fyTokens and Non-tv pools.
    2. Activate the March series
    3. Governance proposal
          i. Orchestrate pools
         ii. Add new series
        iii. Add ilks to the new series
         iv. Initialize new pools
          v. Roll the strategies to the next pool

```
/// @notice Time stretch to be set in the PoolFactory prior to pool deployment
/// @param series identifier (bytes6 tag)
/// @param time stretch (64.64)
export const timeStretch: Map<string, BigNumber> = new Map([
  [FYETH2303, ONE64.div(secondsInOneYear.mul(25))],
  [FYDAI2303, ONE64.div(secondsInOneYear.mul(45))],
  [FYUSDC2303, ONE64.div(secondsInOneYear.mul(55))],
])

/// @notice Sell base to the pool fee, as fp4
export const g1: number = 9000

/// @notice Deploy fyToken series
/// @param series identifier (bytes6 tag)
/// @param underlying identifier (bytes6 tag)
/// @param Address for the chi oracle
/// @param Address for the related Join
/// @param Maturity in unix time (seconds since Jan 1, 1970)
/// @param Name for the series
/// @param Symbol for the series
export const fyTokenData: Array<[string, string, string, string, number, string, string]> = [
  [FYETH2303, ETH, protocol.get(ACCUMULATOR) as string, joins.get(ETH) as string, EOMAR23, 'FYETH2303', 'FYETH2303'],
  [FYDAI2303, DAI, protocol.get(ACCUMULATOR) as string, joins.get(DAI) as string, EOMAR23, 'FYDAI2303', 'FYDAI2303'],
  [
    FYUSDC2303,
    USDC,
    protocol.get(ACCUMULATOR) as string,
    joins.get(USDC) as string,
    EOMAR23,
    'FYUSDC2303',
    'FYUSDC2303',
  ],
]

/// @notice Deploy plain YieldSpace pools
/// @param pool identifier, usually matching the series (bytes6 tag)
/// @param base address
/// @param fyToken address
/// @param time stretch, in 64.64
/// @param g1, in 64.64
export const nonTVPoolData: Array<[string, string, string, BigNumber, number]> = [
  [
    FYETH2303,
    assets.get(ETH) as string,
    newFYTokens.get(FYETH2303) as string,
    timeStretch.get(FYETH2303) as BigNumber,
    g1,
  ],
  [
    FYDAI2303,
    assets.get(DAI) as string,
    newFYTokens.get(FYDAI2303) as string,
    timeStretch.get(FYDAI2303) as BigNumber,
    g1,
  ],
  [
    FYUSDC2303,
    assets.get(USDC) as string,
    newFYTokens.get(FYUSDC2303) as string,
    timeStretch.get(FYUSDC2303) as BigNumber,
    g1,
  ],
]

/// @notice Pool initialization parameters
/// @param pool identifier, usually matching the series (bytes6 tag)
/// @param amount of base to initialize pool with
export const poolsInit: Array<[string, BigNumber]> = [
  [FYETH2303, WAD.div(10)],
  [FYDAI2303, WAD.mul(100)],
  [FYUSDC2303, ONEUSDC.mul(100)],
]

/// @notice Ilks to accept for series
/// @param series identifier (bytes6 tag)
/// @param newly accepted ilks (array of bytes6 tags)
export const seriesIlks: Array<[string, string[]]> = [
  [FYETH2303, [ETH, DAI, USDC]],
  [FYDAI2303, [ETH, DAI, USDC]],
  [FYUSDC2303, [ETH, DAI, USDC]],
]

/// Parameters to roll each strategy
/// @param strategyId
/// @param nextSeriesId
/// @param buffer Amount of base sent to the Roller to make up for market losses when using a flash loan for rolling
/// @param lender ERC3156 flash lender used for rolling
/// @param fix If true, transfer one base wei to the pool to allow the Strategy to start enhanced TV pools
export const rollData: Array<[string, string, BigNumber, string, boolean]> = [
  [YSETH6MMS, FYETH2303, ZERO, ZERO_ADDRESS, false],
  [YSDAI6MMS, FYDAI2303, ZERO, ZERO_ADDRESS, false],
  [YSUSDC6MMS, FYUSDC2303, ZERO, ZERO_ADDRESS, false],
]
```