### PR TITLE
Release Witch v2 to Arbitrum

### DIFF
--- a/YPP-0073.md
+++ b/YPP-0073.md
@@ -39,16 +39,16 @@ export const seriesIds: Array<string> = [FYETH2212, FYUSDC2212, FYETH2303, FYUSD
 /// exceeds this number, no more auctions of for this pair can be started.
 export const v2Limits: AuctionLineAndLimit[] = [
   {
-    baseId: DAI,
-    ilkId: ETH,
+    baseId: ETH,
+    ilkId: DAI,
     duration: 600,
     vaultProportion: parseUnits('0.5'),
     collateralProportion: parseUnits('0.75'), // 105 / 140
-    max: parseUnits('500'),
+    max: parseUnits('1000000'),
   },
   {
-    baseId: DAI,
-    ilkId: USDC,
+    baseId: USDC,
+    ilkId: DAI,
     duration: 600,
     vaultProportion: parseUnits('1'),
     collateralProportion: parseUnits('0.9545454545'), // 105 / 110

--- a/YPP-0073.md
+++ b/YPP-0073.md
@@ -1,0 +1,62 @@
+# Proposal
+Enable Witch v2 on Arbitrum for DAI collateralized positions
+
+# Background
+
+Witch v2 is a more powerful and configurable liquidation engine than Witch v1. The math has been simplified to remove rounding errors, the limits have been changed to reduce risks and match the Cauldron. Payment with fyTokens is now possible. Partial liquidations are also possible.
+
+# Details
+
+In this proposal Witch V2 will be allowed to liquidate DAI collateralized positions. Witch v1 (that old witch) still functions normally and will be able to snatch vaults from Witch v2, so Witch v2 should only do instant liquidations. Witch v2 can't snatch vaults from Witch v1.
+
+If Witch v2 works fine, in further proposals it will get access to more asset pairs, and Witch v1 will be progressively deactivated.
+
+Here are the steps:
+
+1. Deploy Witch V2 (no need for governance approval)
+2. Governance proposal
+   1. Orchestrate Witch v2 with Timelock, Cloak and Cauldron
+   2. Orchestrate Witch v2 with the DAI Join, ETH series and USDC series.
+   3. Set auction parameters for DAI/ETH and DAI/USDC
+   4. Protect Witch v1 from liquidations 
+
+Script that performed said actions: https://github.com/yieldprotocol/environments-v2/blob/c62a9388d84fadba46c24ca4d9c700f72060a31c/scripts/governance/replace/witchV2/activateWitchV2.ts
+
+Configuration applied:
+
+```
+/// The Witch v2 will accept payment in these fyToken
+export const seriesIds: Array<string> = [FYETH2212, FYUSDC2212, FYETH2303, FYUSDC2303]
+
+/// Auction configuration for each asset pair
+/// @param baseId assets in scope as underlying for vaults to be auctioned
+/// @param ilkId assets in scope as collateral for vaults to be auctioned
+/// @param duration time that it takes for the auction to offer maximum collateral
+/// @param vaultProportion proportion of a vault that will be auctioned at a time
+/// @param collateralProportion proportion of the collateral that will be paid out
+/// at the begining of an auction
+/// @param max If the aggregated collateral under auction for vaults of this pair 
+/// exceeds this number, no more auctions of for this pair can be started.
+export const v2Limits: AuctionLineAndLimit[] = [
+  {
+    baseId: DAI,
+    ilkId: ETH,
+    duration: 600,
+    vaultProportion: parseUnits('0.5'),
+    collateralProportion: parseUnits('0.75'), // 105 / 140
+    max: parseUnits('500'),
+  },
+  {
+    baseId: DAI,
+    ilkId: USDC,
+    duration: 600,
+    vaultProportion: parseUnits('1'),
+    collateralProportion: parseUnits('0.9545454545'), // 105 / 110
+    max: parseUnits('1000000'),
+  },
+]
+```
+
+# Testing
+
+Testing will be done on Arbitrum


### PR DESCRIPTION
# Proposal
Enable Witch v2 on Arbitrum for DAI collateralized positions

# Background

Witch v2 is a more powerful and configurable liquidation engine than Witch v1. The math has been simplified to remove rounding errors, the limits have been changed to reduce risks and match the Cauldron. Payment with fyTokens is now possible. Partial liquidations are also possible.

# Details

In this proposal Witch V2 will be allowed to liquidate DAI collateralized positions. Witch v1 (that old witch) still functions normally and will be able to snatch vaults from Witch v2, so Witch v2 should only do instant liquidations. Witch v2 can't snatch vaults from Witch v1.

If Witch v2 works fine, in further proposals it will get access to more asset pairs, and Witch v1 will be progressively deactivated.

Here are the steps:

1. Deploy Witch V2 (no need for governance approval)
2. Governance proposal
   1. Orchestrate Witch v2 with Timelock, Cloak and Cauldron
   2. Orchestrate Witch v2 with the DAI Join, ETH series and USDC series.
   3. Set auction parameters for DAI/ETH and DAI/USDC
   4. Protect Witch v1 from liquidations 

Script that performed said actions: https://github.com/yieldprotocol/environments-v2/blob/c62a9388d84fadba46c24ca4d9c700f72060a31c/scripts/governance/replace/witchV2/activateWitchV2.ts

Configuration applied:

```
/// The Witch v2 will accept payment in these fyToken
export const seriesIds: Array<string> = [FYETH2212, FYUSDC2212, FYETH2303, FYUSDC2303]

/// Auction configuration for each asset pair
/// @param baseId assets in scope as underlying for vaults to be auctioned
/// @param ilkId assets in scope as collateral for vaults to be auctioned
/// @param duration time that it takes for the auction to offer maximum collateral
/// @param vaultProportion proportion of a vault that will be auctioned at a time
/// @param collateralProportion proportion of the collateral that will be paid out
/// at the begining of an auction
/// @param max If the aggregated collateral under auction for vaults of this pair 
/// exceeds this number, no more auctions of for this pair can be started.
export const v2Limits: AuctionLineAndLimit[] = [
  {
    baseId: ETH,
    ilkId: DAI,
    duration: 600,
    vaultProportion: parseUnits('0.5'),
    collateralProportion: parseUnits('0.75'), // 105 / 140
    max: parseUnits('1000000'),
  },
  {
    baseId: USDC,
    ilkId: DAI,
    duration: 600,
    vaultProportion: parseUnits('1'),
    collateralProportion: parseUnits('0.9545454545'), // 105 / 110
    max: parseUnits('1000000'),
  },
]
```

# Testing

Testing will be done on Arbitrum