### PR TITLE
YPP-78 Deploy and add `RepayFromLadleModule` 

### DIFF
--- a/YPP-0078.md
+++ b/YPP-0078.md
@@ -1,0 +1,36 @@
+# Proposal 
+Deploy a RepayFromLadle to the Ladle that allows an an extra argument of an address to be provided for each token transfer.
+
+# Background
+RepayFromLadle sends the collateral and the remainder to the same address. [bugs #1](https://github.com/yieldprotocol/bugs/issues/1)  
+
+# Details
+The proposal includes two mainnet executions...
+1. Deploying the RepayLadleModuleModule using [this script](https://github.com/yieldprotocol/environments-v2/blob/add-repayFromLadleModule/scripts/governance/add/addModule/addModule.sh). The RepayFromLadleModule takes the Cauldron and WETH addresses as constructor arguments. 
+2. Add the RepayFromLadleModule to the Ladle using [this script](https://github.com/yieldprotocol/environments-v2/blob/add-repayFromLadleModule/scripts/governance/add/addModule/addModule.ts).
+
+
+# Testing
+The testing is done on [this test contract](https://github.com/yieldprotocol/vault-v2/blob/master/packages/foundry/contracts/test/modules/RepayCloseModule.t.sol) which uses a mainnet fork
+
+```
+$ forge test -c contracts/test/modules/RepayFromLadleModule.t.sol
+[⠒] Compiling...
+[⠒] Compiling 1 files with 0.8.15
+[⠑] Solc 0.8.15 finished in 1.44s
+Compiler run successful
+
+Running 1 test for contracts/test/modules/RepayCloseModule.t.sol:WithVaultProvisioned
+[PASS] testRepayFromLadle() (gas: 160063)
+Logs:
+  Can repay from ladle
+
+Test result: ok. 1 passed; 0 failed; finished in 2.83s
+
+Running 1 test for contracts/test/modules/RepayCloseModule.t.sol:RepayCloseModuleTest
+[PASS] testOnlyBorrowAndPoolVault() (gas: 436166)
+Logs:
+  can only be used with Borrow and Pool vaults
+
+Test result: ok. 1 passed; 0 failed; finished in 42.13s
+```


### PR DESCRIPTION
# Proposal 
Deploy a RepayFromLadle to the Ladle that allows an an extra argument of an address to be provided for each token transfer.

# Background
RepayFromLadle sends the collateral and the remainder to the same address. [bugs #1](https://github.com/yieldprotocol/bugs/issues/1)  

# Details
The proposal includes two mainnet executions...
1. Deploying the RepayLadleModuleModule using [this script](https://github.com/yieldprotocol/environments-v2/blob/add-repayFromLadleModule/scripts/governance/add/addModule/addModule.sh). The RepayFromLadleModule takes the Cauldron and WETH addresses as constructor arguments. 
2. Add the RepayFromLadleModule to the Ladle using [this script](https://github.com/yieldprotocol/environments-v2/blob/add-repayFromLadleModule/scripts/governance/add/addModule/addModule.ts).


# Testing
The testing is done on [this test contract](https://github.com/yieldprotocol/vault-v2/blob/master/packages/foundry/contracts/test/modules/RepayCloseModule.t.sol) which uses a mainnet fork

```
$ forge test -c contracts/test/modules/RepayFromLadleModule.t.sol
[⠒] Compiling...
[⠒] Compiling 1 files with 0.8.15
[⠑] Solc 0.8.15 finished in 1.44s
Compiler run successful
Running 1 test for contracts/test/modules/RepayCloseModule.t.sol:WithVaultProvisioned
[PASS] testRepayFromLadle() (gas: 160063)
Logs:
  Can repay from ladle
Test result: ok. 1 passed; 0 failed; finished in 2.83s
Running 1 test for contracts/test/modules/RepayCloseModule.t.sol:RepayCloseModuleTest
[PASS] testOnlyBorrowAndPoolVault() (gas: 436166)
Logs:
  can only be used with Borrow and Pool vaults
Test result: ok. 1 passed; 0 failed; finished in 42.13s
```