### PR TITLE
Strategy Lever & Giver Deployment

### DIFF
--- a/YPP-0079.md
+++ b/YPP-0079.md
@@ -1,0 +1,27 @@
+# Proposal
+
+Deploy a strategy lever which allows user to create a leveraged position of strategy token
+
+# Background
+
+The StrategyLever builds on Strategy tokens as collateral to allow leveraged LP positions. While the spread between LP returns and fyToken borrowing rates are unlikely to be very attractive for users right now, this allows us to bootstrap liquidity on the pools at a low cost. Building up liquidity unlocks other features such as stEthLever and CrabLever.
+
+# Details
+
+In this proposal we are going to deploy [Giver](https://github.com/yieldprotocol/vault-v2/blob/master/packages/foundry/contracts/utils/Giver.sol) & [StrategyLever](https://github.com/yieldprotocol/yvarb/blob/47044e8c939d58e997b2c887c6b31a24792f6697/contracts/YieldStrategyLever.sol) and orchestrate them to give relevant permissions.
+
+Steps:
+
+1. Deploy giver (no need for governance approval)
+2. Orchestrate giver
+   1. Grant permission on `Cauldron` for `give` to the `Giver`
+   2. Grant permission on `Giver` for `banIlk` to the `Timelock`
+   3. Remove `ROOT` permission for the deployer on `Giver`
+3. Deploy StrategyLever (no need for governance approval)
+4. Orchestrate Strategy Lever
+   1. Grant permission on `Giver` for `give` to the lever
+   2. Grant permission on `Giver` for `seize` to the lever
+
+# Testing
+
+Testing was done on tenderly & local forks using.

--- a/YPP-0079.md
+++ b/YPP-0079.md
@@ -21,7 +21,8 @@ Steps:
 4. Orchestrate Strategy Lever
    1. Grant permission on `Giver` for `give` to the lever
    2. Grant permission on `Giver` for `seize` to the lever
+5. Set flashFee factor for joins & fyTokens
 
 # Testing
 
-Testing was done on tenderly & local forks using.
+Testing was done on tenderly & local forks.

--- a/YPP-0079.md
+++ b/YPP-0079.md
@@ -23,6 +23,42 @@ Steps:
    2. Grant permission on `Giver` for `seize` to the lever
 5. Set flashFee factor for joins & fyTokens
 
+Configuration parameters:
+```
+// ----- deployment parameters -----
+export const contractDeployments: ContractDeployment[] = [
+  {
+    addressFile: 'protocol.json',
+    name: GIVER,
+    contract: 'Giver',
+    args: [() => protocol().getOrThrow(CAULDRON)],
+  },
+  {
+    addressFile: 'protocol.json',
+    name: YIELD_STRATEGY_LEVER,
+    contract: 'YieldStrategyLever',
+    args: [() => protocol().getOrThrow(GIVER)],
+  },
+]
+
+/// @notice Flashfeefactor to be set on asset's join
+/// @param assetId
+/// @param flashFeeAmount
+export const joinFlashFees: [string, string][] = [
+  ['0x303000000000', '0'],
+  ['0x303100000000', '0'],
+  ['0x303200000000', '0'],
+]
+
+/// @notice Flashfeefactor to be set on fyTokens
+/// @param seriesId
+/// @param flashFee
+export const fyTokenFlashFees: [string, string][] = [
+  ['0x303030380000', '0'],
+  ['0x303130380000', '0'],
+  ['0x303230380000', '0'],
+]
+```
 # Testing
 
 Testing was done on tenderly & local forks.


### PR DESCRIPTION
# Proposal

Deploy a strategy lever which allows user to create a leveraged position of strategy token

# Background

The StrategyLever builds on Strategy tokens as collateral to allow leveraged LP positions. While the spread between LP returns and fyToken borrowing rates are unlikely to be very attractive for users right now, this allows us to bootstrap liquidity on the pools at a low cost. Building up liquidity unlocks other features such as stEthLever and CrabLever.

# Details

In this proposal we are going to deploy [Giver](https://github.com/yieldprotocol/vault-v2/blob/master/packages/foundry/contracts/utils/Giver.sol) & [StrategyLever](https://github.com/yieldprotocol/yvarb/blob/47044e8c939d58e997b2c887c6b31a24792f6697/contracts/YieldStrategyLever.sol) and orchestrate them to give relevant permissions.

Steps:

1. Deploy giver (no need for governance approval)
2. Orchestrate giver
   1. Grant permission on `Cauldron` for `give` to the `Giver`
   2. Grant permission on `Giver` for `banIlk` to the `Timelock`
   3. Remove `ROOT` permission for the deployer on `Giver`
3. Deploy StrategyLever (no need for governance approval)
4. Orchestrate Strategy Lever
   1. Grant permission on `Giver` for `give` to the lever
   2. Grant permission on `Giver` for `seize` to the lever
5. Set flashFee factor for joins & fyTokens

Configuration parameters:
```
// ----- deployment parameters -----
export const contractDeployments: ContractDeployment[] = [
  {
    addressFile: 'protocol.json',
    name: GIVER,
    contract: 'Giver',
    args: [() => protocol().getOrThrow(CAULDRON)],
  },
  {
    addressFile: 'protocol.json',
    name: YIELD_STRATEGY_LEVER,
    contract: 'YieldStrategyLever',
    args: [() => protocol().getOrThrow(GIVER)],
  },
]

/// @notice Flashfeefactor to be set on asset's join
/// @param assetId
/// @param flashFeeAmount
export const joinFlashFees: [string, string][] = [
  ['0x303000000000', '0'],
  ['0x303100000000', '0'],
  ['0x303200000000', '0'],
]

/// @notice Flashfeefactor to be set on fyTokens
/// @param seriesId
/// @param flashFee
export const fyTokenFlashFees: [string, string][] = [
  ['0x303030380000', '0'],
  ['0x303130380000', '0'],
  ['0x303230380000', '0'],
]
```
# Testing

Testing was done on tenderly & local forks.
