### PR TITLE
Fix orchestration on NotionalJoins

### DIFF
--- a/YPP-0081.md
+++ b/YPP-0081.md
@@ -1,0 +1,14 @@
+# Proposal
+Allow NotionalJoins to move assets to and from the Joins for their underlying.
+
+# Background
+
+In the recent FCash as collateral release, the orchestration between the NotionalJoins and their underlying Joins is missing. There is no impact yet, but after FCash maturity any asset movements involving NotionalJoins would revert.
+
+# Details
+
+The [orchestration script](https://github.com/yieldprotocol/environments-v2/blob/a5d82ae150fe59b7fb6accfa358a04a7213df373/scripts/fragments/other/notional/orchestrateNotionalJoinProposal.ts#L40) has been fixed to include `join` and `exit` permissions for each NotionalJoin on their underlying Join. No parameters are required beyond the [addresses of the NotionalJoins](https://github.com/yieldprotocol/environments-v2/blob/a5d82ae150fe59b7fb6accfa358a04a7213df373/addresses/mainnet/newJoins.json).
+
+# Testing
+
+Testing has been done on [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/675f54a2-db83-475f-ac02-c184f3d95aef).


### PR DESCRIPTION
# Proposal
Allow NotionalJoins to move assets to and from the Joins for their underlying.

# Background

In the recent FCash as collateral release, the orchestration between the NotionalJoins and their underlying Joins is missing. There is no impact yet, but after FCash maturity any asset movements involving NotionalJoins would revert.

# Details

The [orchestration script](https://github.com/yieldprotocol/environments-v2/blob/a5d82ae150fe59b7fb6accfa358a04a7213df373/scripts/fragments/other/notional/orchestrateNotionalJoinProposal.ts#L40) has been fixed to include `join` and `exit` permissions for each NotionalJoin on their underlying Join. No parameters are required beyond the [addresses of the NotionalJoins](https://github.com/yieldprotocol/environments-v2/blob/a5d82ae150fe59b7fb6accfa358a04a7213df373/addresses/mainnet/newJoins.json).

# Testing

Testing has been done on [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/675f54a2-db83-475f-ac02-c184f3d95aef).
