### PR TITLE
YPP-82: Redeploy `YieldMath.sol`

### DIFF
--- a/YPP-0082.md
+++ b/YPP-0082.md
@@ -1,0 +1,14 @@
+# Proposal
+Redeploys latest version of `YieldMath.sol`. 
+
+# Background
+
+The previous version of `YieldMath.sol` had three underflows highlighted [here](https://github.com/yieldprotocol/yieldspace-tv/issues/75) and [here](https://github.com/yieldprotocol/yieldspace-tv/issues/76).
+
+# Details
+
+The [deploy script](https://github.com/yieldprotocol/environments-v2/blob/deploy-new-yieldmath/scripts/governance/redeploy/yieldmath/redeployYieldMath.sh) and its respective [config file](https://github.com/yieldprotocol/environments-v2/blob/deploy-new-yieldmath/scripts/governance/redeploy/yieldmath/redeployYieldMath.mainnet.config.ts).
+
+# Testing
+
+Testing has been done on [here](https://github.com/yieldprotocol/yieldspace-tv/blob/main/src/test/YieldMath.t.sol).


### PR DESCRIPTION
# Proposal
Redeploys latest version of `YieldMath.sol`. 

# Background

The previous version of `YieldMath.sol` had three underflows highlighted [here](https://github.com/yieldprotocol/yieldspace-tv/issues/75) and [here](https://github.com/yieldprotocol/yieldspace-tv/issues/76).

# Details

The [deploy script](https://github.com/yieldprotocol/environments-v2/blob/deploy-new-yieldmath/scripts/governance/redeploy/yieldmath/redeployYieldMath.sh) and its respective [config file](https://github.com/yieldprotocol/environments-v2/blob/deploy-new-yieldmath/scripts/governance/redeploy/yieldmath/redeployYieldMath.mainnet.config.ts).

# Testing

Testing has been done on [here](https://github.com/yieldprotocol/yieldspace-tv/blob/main/src/test/YieldMath.t.sol).
