### PR TITLE
Distribute ETH Rewards from YSETH6MJD for December

### DIFF
--- a/YPP-0084.md
+++ b/YPP-0084.md
@@ -1,0 +1,30 @@
+# Proposal
+
+Add WETH Rewards for YSETH6MJD for the month of December.
+
+# Background
+
+Our strategies have a built-in capability to distribute rewards that hasn't been tested yet on mainnet. The outgoing v1 strategies offer a good opportunity to do some real life testing.
+
+# Details
+
+Here are the steps:
+
+1. Set WETH as the rewards token, and set YSETH6MJD to distribute 10 ETH over the month of December.
+
+Script that performed said actions: https://github.com/yieldprotocol/environments-v2/blob/0494d4e9131a8f6ab6eba13ff085e3e8f0e16f58/scripts/governance/add/addRewards/addEthRewards/addEthRewards.ts
+
+Configuration applied:
+
+```typescript
+export const rewardsData: Array<[string, string, number, number, number]> = [
+  // strategyId, rewardsTokenAddress, rewards start, rewards stop, rewards rate
+  [YSETH6MJD, assets.getOrThrow(ETH)!, 1669852800, 1672531199, 3733573675916],
+]
+```
+
+The contracts have been deployed to Arbitrum mainnet and the proposal sent to the multisig.
+
+# Testing
+
+We'll do testing on mainnet. YOLO.


### PR DESCRIPTION
# Proposal

Add WETH Rewards for YSETH6MJD for the month of December.

# Background

Our strategies have a built-in capability to distribute rewards that hasn't been tested yet on mainnet. The outgoing v1 strategies offer a good opportunity to do some real life testing.

# Details

Here are the steps:

1. Set WETH as the rewards token, and set YSETH6MJD to distribute 10 ETH over the month of December.

Script that performed said actions: https://github.com/yieldprotocol/environments-v2/blob/0494d4e9131a8f6ab6eba13ff085e3e8f0e16f58/scripts/governance/add/addRewards/addEthRewards/addEthRewards.ts

Configuration applied:

```typescript
export const rewardsData: Array<[string, string, number, number, number]> = [
  // strategyId, rewardsTokenAddress, rewards start, rewards stop, rewards rate
  [YSETH6MJD, assets.getOrThrow(ETH)!, 1669852800, 1672531199, 3733573675916],
]
```

The contracts have been deployed to Arbitrum mainnet and the proposal sent to the multisig.

# Testing

We'll do testing on mainnet. YOLO.