### PR TITLE
Replace Notional ETH Joins for fixed ones

### DIFF
--- a/YPP-0085.md
+++ b/YPP-0085.md
@@ -1,0 +1,72 @@
+# Proposal
+Replace ETH NotionalJoins for a fixed version that can accept Ether on redemption.
+
+# Background
+
+Notional sends unwrapped Ether on redemption, while our NotionalJoin would expect WETH. A fixed version that wraps the ETH into WETH will be swapped in.
+
+# Details
+
+The swap is encoded in this [script](https://github.com/yieldprotocol/environments-v2/blob/014a25bc6538a8800a2cb8e070f9010933b42604/scripts/governance/replace/notionalJoins/replaceNotionalJoins.ts).
+
+1. Orchestrate the new Joins
+2. Add the new Joins to the Ladle
+3. Move funds from old Joins to new Joins
+4. Isolate old Joins from Ladle
+
+Contract deployments:
+```
+export const contractDeployments: ContractDeployment[] = [
+  /// @param fCashAddress Address for the notional contract
+  /// @param underlyingAddress Address for the underlying asset
+  /// @param underlyingJoinAddress Address for the join of the underlying asset
+  /// @param maturity Maturity of the Notional series, in unix time
+  /// @param currencyId Notional currency id
+  {
+    addressFile: 'joins.json',
+    name: FETH2212,
+    contract: 'NotionalJoin',
+    args: [
+      () => external.getOrThrow(FCASH),
+      () => assets.getOrThrow(ETH),
+      () => joins.getOrThrow(ETH),
+      () => FCASH_DEC22,
+      () => FCASH_ETH,
+    ],
+  },
+  {
+    addressFile: 'joins.json',
+    name: FETH2303,
+    contract: 'NotionalJoin',
+    args: [
+      () => external.getOrThrow(FCASH),
+      () => assets.getOrThrow(ETH),
+      () => joins.getOrThrow(ETH),
+      () => FCASH_MAR23,
+      () => FCASH_ETH,
+    ],
+  },
+]
+```
+
+Proposal configuration:
+```
+export const newJoins = new Map<string, string>([
+  [FETH2212, joins.getOrThrow(FETH2212)],
+  [FETH2303, joins.getOrThrow(FETH2303)],
+])
+
+export const newAssets = [
+  [FETH2212, external.getOrThrow(FCASH), joins.getOrThrow(FETH2212)],
+  [FETH2303, external.getOrThrow(FCASH), joins.getOrThrow(FETH2303)],
+]
+
+export const joinReplacements = [
+  [oldJoins.getOrThrow(FETH2212), joins.getOrThrow(FETH2212)],
+  [oldJoins.getOrThrow(FETH2303), joins.getOrThrow(FETH2303)],
+]
+```
+
+# Testing
+
+Testing has been done on [this tenderly fork]().


### PR DESCRIPTION
# Proposal
Replace ETH NotionalJoins for a fixed version that can accept Ether on redemption.

# Background

Notional sends unwrapped Ether on redemption, while our NotionalJoin would expect WETH. A fixed version that wraps the ETH into WETH will be swapped in.

# Details

The swap is encoded in this [script](https://github.com/yieldprotocol/environments-v2/blob/014a25bc6538a8800a2cb8e070f9010933b42604/scripts/governance/replace/notionalJoins/replaceNotionalJoins.ts).

1. Orchestrate the new Joins
2. Add the new Joins to the Ladle
3. Move funds from old Joins to new Joins
4. Isolate old Joins from Ladle

Contract deployments:
```
export const contractDeployments: ContractDeployment[] = [
  /// @param fCashAddress Address for the notional contract
  /// @param underlyingAddress Address for the underlying asset
  /// @param underlyingJoinAddress Address for the join of the underlying asset
  /// @param maturity Maturity of the Notional series, in unix time
  /// @param currencyId Notional currency id
  {
    addressFile: 'joins.json',
    name: FETH2212,
    contract: 'NotionalJoin',
    args: [
      () => external.getOrThrow(FCASH),
      () => assets.getOrThrow(ETH),
      () => joins.getOrThrow(ETH),
      () => FCASH_DEC22,
      () => FCASH_ETH,
    ],
  },
  {
    addressFile: 'joins.json',
    name: FETH2303,
    contract: 'NotionalJoin',
    args: [
      () => external.getOrThrow(FCASH),
      () => assets.getOrThrow(ETH),
      () => joins.getOrThrow(ETH),
      () => FCASH_MAR23,
      () => FCASH_ETH,
    ],
  },
]
```

Proposal configuration:
```
export const newJoins = new Map<string, string>([
  [FETH2212, joins.getOrThrow(FETH2212)],
  [FETH2303, joins.getOrThrow(FETH2303)],
])

export const newAssets = [
  [FETH2212, external.getOrThrow(FCASH), joins.getOrThrow(FETH2212)],
  [FETH2303, external.getOrThrow(FCASH), joins.getOrThrow(FETH2303)],
]

export const joinReplacements = [
  [oldJoins.getOrThrow(FETH2212), joins.getOrThrow(FETH2212)],
  [oldJoins.getOrThrow(FETH2303), joins.getOrThrow(FETH2303)],
]
```

# Testing

Testing has been done on [this tenderly fork]().
