### PR TITLE
YPP-92: Remove developers

### DIFF
--- a/YPP-0092.md
+++ b/YPP-0092.md
@@ -1,0 +1,17 @@
+# Proposal
+
+Remove developer roles on mainnet and arbitrum from:
+
+  '0x08462a2a815FE5B65D67AaC8d928C21Be2f9dDAE', controlled by David
+  '0xa1a58E83AD7367f04501d454c7d010AB01C29d04', controlled by Raja
+  '0xfe90d993367bc93D171A5ED88ab460759DE2bED6', controlled by Richie
+
+# Background
+
+The three developers in this proposal are not expected to execute proposals for Yield Protocol anymore
+
+# Details
+
+The [revokeDevelopers](https://github.com/yieldprotocol/environments-v2/blob/6e7eaccd91d2b18d8149cafa4b8fbf2b84b69a00/scripts/governance/permissions/revokeDevelopers/revokeDevelopers.sh) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/6e7eaccd91d2b18d8149cafa4b8fbf2b84b69a00/scripts/governance/permissions/revokeDevelopers/revokeDevelopers.config.ts).
+
+Permissions on the Cloak v1 are not being removed, since it is being decommissioned shortly.


### PR DESCRIPTION
# Proposal

Remove developer roles on mainnet and arbitrum from:

  '0x08462a2a815FE5B65D67AaC8d928C21Be2f9dDAE', controlled by David
  '0xa1a58E83AD7367f04501d454c7d010AB01C29d04', controlled by Raja
  '0xfe90d993367bc93D171A5ED88ab460759DE2bED6', controlled by Richie

# Background

The three developers in this proposal are not expected to execute proposals for Yield Protocol anymore

# Details

The [revokeDevelopers](https://github.com/yieldprotocol/environments-v2/blob/6e7eaccd91d2b18d8149cafa4b8fbf2b84b69a00/scripts/governance/permissions/revokeDevelopers/revokeDevelopers.sh) script will be used, with [this input](https://github.com/yieldprotocol/environments-v2/blob/6e7eaccd91d2b18d8149cafa4b8fbf2b84b69a00/scripts/governance/permissions/revokeDevelopers/revokeDevelopers.config.ts).

Permissions on the Cloak v1 are not being removed, since it is being decommissioned shortly.