### PR TITLE
YPP-93: Unprotect Witch v1 on mainnet

### DIFF
--- a/YPP-0093.md
+++ b/YPP-0093.md
@@ -1,0 +1,9 @@
+# Proposal
+Unprotect the Witch v1 on mainnet
+
+# Background
+The Witch v1 is not active anymore, but still holds one vault under auction that can never be liquidated for as long as the Witch v1 holds it. Unprotecting the Witch v1 in Witch v2 will allow that vault to be auctioned in Witch v2.
+
+# Details
+The [unprotectWitchV1.ts](https://github.com/yieldprotocol/environments-v2/blob/74ccdd1f18e5402501273a5f321f7ad8ea51cb38/scripts/governance/update/updateProtected/unprotectWitchV1.ts) script will be used, with no input required.
+


### PR DESCRIPTION
# Proposal
Unprotect the Witch v1 on mainnet

# Background
The Witch v1 is not active anymore, but still holds one vault under auction that can never be liquidated for as long as the Witch v1 holds it. Unprotecting the Witch v1 in Witch v2 will allow that vault to be auctioned in Witch v2.

# Details
The [unprotectWitchV1.ts](https://github.com/yieldprotocol/environments-v2/blob/74ccdd1f18e5402501273a5f321f7ad8ea51cb38/scripts/governance/update/updateProtected/unprotectWitchV1.ts) script will be used, with no input required.

