### PR TITLE
Adjust Contango permissions

### DIFF
--- a/YPP-0100.md
+++ b/YPP-0100.md
@@ -1,0 +1,17 @@
+# Proposal
+
+Adjust permissions on mainnet and arbitrum for contango developers. More specifically, grant developer permissions to Bruno on mainnet, and remove executor permissions on the arbitrum cloak from Egill.
+
+0x05950b4e68f103d5aBEf20364dE219a247e59C23: Bruno Bonnano
+0x02f73B54ccfBA5c91bf432087D60e4b3a781E497: Egill Hreinsson
+
+# Background
+
+Bruno requires developer permissions to have some redundancy on mainnet, were only Egill is a developer on the Contango team.
+Upon discussion, it was agreed that Contango developers wouldn't have permissions on the Cloak, despite the Contango contracts being under the Cloak control. This gives Yield permission to quickly isolate Contango, but doesn't open Yield to a governance attack from Contango.
+
+# Details
+
+On mainnet, the [addDevelopers](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/addDevelopers) script will be used first, to give developer permissions to Bruno. Afterwards, the [revokeCloakExecution]() script will be used, to remove Bruno and Egill from the cloak executor role.
+
+On arbitrum, the [revokeCloakExecution]() script will be used, to remove Egill from the cloak executor role.

--- a/YPP-0100.md
+++ b/YPP-0100.md
@@ -12,6 +12,6 @@ Upon discussion, it was agreed that Contango developers wouldn't have permission
 
 # Details
 
-On mainnet, the [addDevelopers](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/addDevelopers) script will be used first, to give developer permissions to Bruno. Afterwards, the [revokeCloakExecution]() script will be used, to remove Bruno and Egill from the cloak executor role.
+On mainnet, the [addDevelopers](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/addDevelopers) script will be used first, to give developer permissions to Bruno. Afterwards, the [revokeCloakExecution](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/revokeCloakExecute) script will be used, to remove Bruno and Egill from the cloak executor role.
 
-On arbitrum, the [revokeCloakExecution]() script will be used, to remove Egill from the cloak executor role.
+On arbitrum, the [revokeCloakExecution](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/revokeCloakExecute) script will be used, to remove Egill from the cloak executor role.


### PR DESCRIPTION
# Proposal

Adjust permissions on mainnet and arbitrum for contango developers. More specifically, grant developer permissions to Bruno on mainnet, and remove executor permissions on the arbitrum cloak from Egill.

0x05950b4e68f103d5aBEf20364dE219a247e59C23: Bruno Bonnano
0x02f73B54ccfBA5c91bf432087D60e4b3a781E497: Egill Hreinsson

# Background

Bruno requires developer permissions to have some redundancy on mainnet, were only Egill is a developer on the Contango team.
Upon discussion, it was agreed that Contango developers wouldn't have permissions on the Cloak, despite the Contango contracts being under the Cloak control. This gives Yield permission to quickly isolate Contango, but doesn't open Yield to a governance attack from Contango.

# Details

On mainnet, the [addDevelopers](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/addDevelopers) script will be used first, to give developer permissions to Bruno. Afterwards, the [revokeCloakExecution](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/revokeCloakExecute) script will be used, to remove Bruno and Egill from the cloak executor role.

On arbitrum, the [revokeCloakExecution](https://github.com/yieldprotocol/environments-v2/tree/feat/developer-permissions/scripts/governance/permissions/revokeCloakExecute) script will be used, to remove Egill from the cloak executor role.