### PR TITLE
Assert.sol integration

### DIFF
--- a/YPP-0108.md
+++ b/YPP-0108.md
@@ -1,11 +1,11 @@
 # Proposal
-Add Assert.sol as a ladle integration on Mainnet and Arbitrum
+Add Assert.sol as a Ladle integration on Mainnet and Arbitrum
 
 # Background
 
 Generally, interaction with the protocol is done through a set of encoded transactions sent to the Ladle (via the batch() function). These transactions each run in isolation and and have no notion of the overall intent of the interaction. This means that incorrectly structured transaction sets could potentially 'succeed', but not have the intended result.    
 
-This integration adds the ability to check if a ladle batch transaction meets an arbitrary expected outcome. An call to Assert.sol is added to the batch (typically at the end), if the assertion fails, so does the entire batch. 
+This integration adds the ability to check if a ladle batch transaction meets an arbitrary expected outcome. An call to Assert.sol is added to the batch (typically at the end), if the assertion fails, so does the entire batch.
 
 # Details
 
@@ -13,6 +13,5 @@ This integration adds the ability to check if a ladle batch transaction meets an
 Manual verification of state changes on Mainnet can be seen on this fork [this tenderly fork]( https://dashboard.tenderly.co/Yield/v2/fork/419b6a25-238a-41b4-bb8a-d8d7fe0b0fd1/simulation/8018db4a-9fea-4ed9-ac34-594616a0b645/state-diff).
 
 
-Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork]( 
-
+Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/f24b59a8-db83-4d2c-a244-77b665a2b6ce/simulation/a1691c27-1238-4616-b18b-7314f061ec6f 
 ).

--- a/YPP-0108.md
+++ b/YPP-0108.md
@@ -1,11 +1,18 @@
 # Proposal
-Add Assert.sol as a ladle integration
+Add Assert.sol as a ladle integration on Mainnet and Arbitrum
 
 # Background
 
+Generally, interaction with the protocol is done through a set of encoded transactions sent to the Ladle (via the batch() function). These transactions each run in isolation and and have no notion of the overall intent of the interaction. This means that incorrectly structured transaction sets could potentially 'succeed', but not have the intended result.    
 
+This integration adds the ability to check if a ladle batch transaction meets an arbitrary expected outcome. An call to Assert.sol is added to the batch (typically at the end), if the assertion fails, so does the entire batch. 
 
 # Details
 
 # Testing
-Manual verification of state changes on [this tenderly fork]( ).
+Manual verification of state changes on Mainnet can be seen on this fork [this tenderly fork]( https://dashboard.tenderly.co/Yield/v2/fork/419b6a25-238a-41b4-bb8a-d8d7fe0b0fd1/simulation/8018db4a-9fea-4ed9-ac34-594616a0b645/state-diff).
+
+
+Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork]( 
+
+).

--- a/YPP-0108.md
+++ b/YPP-0108.md
@@ -15,3 +15,11 @@ Manual verification of state changes on Mainnet can be seen on this fork [this t
 
 Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/2c063048-b86a-4b52-95e1-77857426f54a
 ).
+
+Mainnet: 
+Executed 0x3a4d5c2ad6b0c8e3df23a59f6e5a43f6f3d531461ebf9dac1cf51932cb975f40
+TxHash: 0x4046b3cd59ba6decd4a71bc92efc507df1429a2f0256c7952529ed537ed4a18a
+
+Arbitrum: 
+Executed 0x31c130743ba866b683c8a90b8123c2cfa83c800bf918c75800e730d74e5a47ba
+TxHash: 0x57010786d0d52ba878ac7fe00d96d624a6b9d200207642f033ee5ad36039e3d5

--- a/YPP-0108.md
+++ b/YPP-0108.md
@@ -5,13 +5,13 @@ Add Assert.sol as a Ladle integration on Mainnet and Arbitrum
 
 Generally, interaction with the protocol is done through a set of encoded transactions sent to the Ladle (via the batch() function). These transactions each run in isolation and and have no notion of the overall intent of the interaction. This means that incorrectly structured transaction sets could potentially 'succeed', but not have the intended result.    
 
-This integration adds the ability to check if a ladle batch transaction meets an arbitrary expected outcome. An call to Assert.sol is added to the batch (typically at the end), if the assertion fails, so does the entire batch.
-
-# Details
+This integration adds the ability to check if a ladle batch transaction meets an arbitrary expected outcome. An call to Assert.sol (deployed at  0x40f0b18C7A41C04F848C033eD7F9178D9c5A80d8 ) is added to the batch (typically at the end), if the assertion fails, so does the entire batch.
 
 # Testing
-Manual verification of state changes on Mainnet can be seen on this fork [this tenderly fork]( https://dashboard.tenderly.co/Yield/v2/fork/419b6a25-238a-41b4-bb8a-d8d7fe0b0fd1/simulation/8018db4a-9fea-4ed9-ac34-594616a0b645/state-diff).
 
+Testing was done on a tenderly fork:
 
-Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/f24b59a8-db83-4d2c-a244-77b665a2b6ce/simulation/a1691c27-1238-4616-b18b-7314f061ec6f 
+Manual verification of state changes on Mainnet can be seen on this fork [this tenderly fork]( https://dashboard.tenderly.co/Yield/v2/fork/b6952bd3-a288-48c5-bf5c-7ed00a2a88ea).
+
+Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/2c063048-b86a-4b52-95e1-77857426f54a
 ).

--- a/YPP-0108.md
+++ b/YPP-0108.md
@@ -1,0 +1,11 @@
+# Proposal
+Add Assert.sol as a ladle integration
+
+# Background
+
+
+
+# Details
+
+# Testing
+Manual verification of state changes on [this tenderly fork]( ).


### PR DESCRIPTION
# Proposal
Add Assert.sol as a Ladle integration on Mainnet and Arbitrum

# Background

Generally, interaction with the protocol is done through a set of encoded transactions sent to the Ladle (via the batch() function). These transactions each run in isolation and and have no notion of the overall intent of the interaction. This means that incorrectly structured transaction sets could potentially 'succeed', but not have the intended result.    

This integration adds the ability to check if a ladle batch transaction meets an arbitrary expected outcome. An call to Assert.sol is added to the batch (typically at the end), if the assertion fails, so does the entire batch.

# Details

# Testing
Manual verification of state changes on Mainnet can be seen on this fork [this tenderly fork]( https://dashboard.tenderly.co/Yield/v2/fork/419b6a25-238a-41b4-bb8a-d8d7fe0b0fd1/simulation/8018db4a-9fea-4ed9-ac34-594616a0b645/state-diff).


Manual verification of state changes on Arbitrum can be seen on this fork [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/f24b59a8-db83-4d2c-a244-77b665a2b6ce/simulation/a1691c27-1238-4616-b18b-7314f061ec6f 
).