### PR TITLE
Restore protocol

### DIFF
--- a/YPP-0113.md
+++ b/YPP-0113.md
@@ -1,0 +1,18 @@
+# Proposal
+Deploy new June-December Strategies and June Series, at the same level as they were at the time of the Euler hack. 
+Deploy new March-September Strategies and September Series, at an equivalent level as they were at the time of the Euler hack. 
+Update all underlyings and fyToken will use the Accumulator Oracle for chi and rate.
+Migrate all existing June vaults to the alternative June series.
+
+# Background
+Once the funds have been recovered from the Euler hack, the protocol is being restarted. The March series is matured, so those funds are going to a new September series simulating a strategy roll. September fyToken are being minted and provided to the new pools with a value close to the March fyToken that became locked in the affected pools. The June series is being duplicated on new contracts with a new series id, but otherwise identical to the old series. June debtors are being automatically migrated to the new June series with the same debt as they had. In addition, all series are being updated to use the Accumulator oracle at chi 0% and rate 5%, instead of relying on Compound for these values.
+
+# Details
+All code relevant to this proposal is available [here](https://github.com/yieldprotocol/environments-v2/tree/fix/euler-hack).
+
+# Testing
+This proposal has been tested as follows:
+ - Test harnesses from [addendum-docs](https://github.com/yieldprotocol/addendum-docs) for new pools.
+ - Test harnesses from [strategy-v2](https://github.com/yieldprotocol/strategy-v2) for new strategies.
+ - Manual verification of state changes on [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/bd0404ae-1bbc-4e6f-acca-b86be7f12ac7).
+ - Frontend testing


### PR DESCRIPTION
# Proposal
Deploy new June-December Strategies and June Series, at the same level as they were at the time of the Euler hack. 
Deploy new March-September Strategies and September Series, at an equivalent level as they were at the time of the Euler hack. 
Update all underlyings and fyToken will use the Accumulator Oracle for chi and rate.
Migrate all existing June vaults to the alternative June series.

# Background
Once the funds have been recovered from the Euler hack, the protocol is being restarted. The March series is matured, so those funds are going to a new September series simulating a strategy roll. September fyToken are being minted and provided to the new pools with a value close to the March fyToken that became locked in the affected pools. The June series is being duplicated on new contracts with a new series id, but otherwise identical to the old series. June debtors are being automatically migrated to the new June series with the same debt as they had. In addition, all series are being updated to use the Accumulator oracle at chi 0% and rate 5%, instead of relying on Compound for these values.

# Details
All code relevant to this proposal is available [here](https://github.com/yieldprotocol/environments-v2/tree/fix/euler-hack).

# Testing
This proposal has been tested as follows:
 - Test harnesses from [addendum-docs](https://github.com/yieldprotocol/addendum-docs) for new pools.
 - Test harnesses from [strategy-v2](https://github.com/yieldprotocol/strategy-v2) for new strategies.
 - Manual verification of state changes on [this tenderly fork](https://dashboard.tenderly.co/Yield/v2/fork/bd0404ae-1bbc-4e6f-acca-b86be7f12ac7).
 - Frontend testing